### PR TITLE
Update LC5-POD.cfg

### DIFF
--- a/GameData/SSTU/Parts/LanderCore/LC5-POD.cfg
+++ b/GameData/SSTU/Parts/LanderCore/LC5-POD.cfg
@@ -39,7 +39,7 @@ node_stack_bottom = 0,-1.41027,0,0,-1,0,2
 attachRules = 1,0,1,1,1
 
 // --- standard part parameters ---
-mass = 4.5
+mass = 3.4
 maximum_drag = 0.2
 minimum_drag = 0.2
 angularDrag = 2


### PR DESCRIPTION
lower weight to match B-CMX to make it more viable to use as a lander (using only the CMX right now)
