### PR TITLE
Allow SSTU to set part cost on ModuleEngineConfigs

### DIFF
--- a/GameData/SSTU/Patches/EngineMassHandling.cfg
+++ b/GameData/SSTU/Patches/EngineMassHandling.cfg
@@ -6,6 +6,5 @@
 	@MODULE[SSTUModularEngineCluster]
 	{
 		%adjustMass = false
-		%adjustCost = false
 	}
 }


### PR DESCRIPTION
Unsure why this was a thing, it seems the bug for cost was in realfuels.

https://github.com/NathanKell/ModularFuelSystem/pull/149
https://github.com/KSP-RO/RP-0/issues/538
