### PR TITLE
preliminary rcs patch

### DIFF
--- a/GameData/SSTU/Parts/LanderCore/LC2-POD.cfg
+++ b/GameData/SSTU/Parts/LanderCore/LC2-POD.cfg
@@ -13,6 +13,37 @@ title = SSTU - LC2-POD
 manufacturer = SSTU
 description = LC2-POD
 
+EFFECTS
+{
+	running
+	{
+		AUDIO_MULTI_POOL
+		{
+			channel = Ship
+			transformName = SC-GEN-RCS-4A-V-ThrustTransform
+			clip = sound_rocket_mini
+			volume = 0.0 0.0
+			volume = 0.1 0.0
+			volume = 0.5 0.025
+			volume = 1.0 0.1
+			pitch = 0.0 0.75
+			pitch = 1.0 1.5
+			loop = true
+		}
+		MODEL_MULTI_PARTICLE
+		{
+			modelName = Squad/FX/Monoprop_small
+			transformName = SC-GEN-RCS-4A-V-ThrustTransform
+			emission = 0.0 0.0
+			emission = 0.1 0.0
+			emission = 1.0 1.0
+			speed = 0.0 0.8
+			speed = 1.0 1.0
+			localRotation = -90, 0, 0
+		}
+	}		
+}
+
 MODEL
 {
 	model = SSTU/Assets/LC2-POD
@@ -81,11 +112,12 @@ MODULE
 }
 MODULE
 {
-	name = ModuleRCS
+	name = ModuleRCSFX
 	thrusterTransformName = SC-GEN-RCS-4A-V-ThrustTransform
 	thrusterPower = 0.5
 	resourceName = MonoPropellant
 	resourceFlowMode = STAGE_PRIORITY_FLOW
+	runningEffectName = running
 	atmosphereCurve
  	{
    		key = 0 260

--- a/GameData/SSTU/Parts/LanderCore/LC2-POD.cfg
+++ b/GameData/SSTU/Parts/LanderCore/LC2-POD.cfg
@@ -115,14 +115,25 @@ MODULE
 	name = ModuleRCSFX
 	thrusterTransformName = SC-GEN-RCS-4A-V-ThrustTransform
 	thrusterPower = 0.5
-	resourceName = MonoPropellant
-	resourceFlowMode = STAGE_PRIORITY_FLOW
 	runningEffectName = running
+	PROPELLANT
+	{
+		name = Aerozine50
+		ratio = 1
+		DrawGauge = True
+		resourceFlowMode = STAGE_PRIORITY_FLOW
+	}
+	PROPELLANT
+	{
+		name = NTO
+		ratio = 1
+		resourceFlowMode = STAGE_PRIORITY_FLOW
+	}
 	atmosphereCurve
- 	{
-   		key = 0 260
+	{
+		key = 0 280
 		key = 1 100
- 	}
+	}
 }
 MODULE
 {
@@ -262,9 +273,10 @@ MODULE
 		tankageMass = 0
 		ecHasMass = false
 		defaultModifier = standard
-		defaultResources = MonoPropellant,1;ElectricCharge,12
-		resource = MonoPropellant
-		resource = ElectricCharge
+		defaultResources = Aerozine50,2;NTO,2;ElectricCharge,24
+		resource = Aerozine50
+		resource = NTO
+		resource = ElectricCharge 
 		modifier = standard
 	}
 	CONTAINER

--- a/GameData/SSTU/Parts/LanderCore/LC3-POD.cfg
+++ b/GameData/SSTU/Parts/LanderCore/LC3-POD.cfg
@@ -13,6 +13,37 @@ title = SSTU - LC3-POD
 manufacturer = SSTU
 description = LC3-POD
 
+EFFECTS
+{
+	running
+	{
+		AUDIO_MULTI_POOL
+		{
+			channel = Ship
+			transformName = SC-GEN-RCS-4A-V-ThrustTransform
+			clip = sound_rocket_mini
+			volume = 0.0 0.0
+			volume = 0.1 0.0
+			volume = 0.5 0.025
+			volume = 1.0 0.1
+			pitch = 0.0 0.75
+			pitch = 1.0 1.5
+			loop = true
+		}
+		MODEL_MULTI_PARTICLE
+		{
+			modelName = Squad/FX/Monoprop_small
+			transformName = SC-GEN-RCS-4A-V-ThrustTransform
+			emission = 0.0 0.0
+			emission = 0.1 0.0
+			emission = 1.0 1.0
+			speed = 0.0 0.8
+			speed = 1.0 1.0
+			localRotation = -90, 0, 0
+		}
+	}		
+}
+
 MODEL
 {
 	model = SSTU/Assets/LC3-POD
@@ -87,11 +118,12 @@ MODULE
 }
 MODULE
 {
-	name = ModuleRCS
+	name = ModuleRCSFX
 	thrusterTransformName = SC-GEN-RCS-4A-V-ThrustTransform
 	thrusterPower = 0.5
 	resourceName = MonoPropellant
 	resourceFlowMode = STAGE_PRIORITY_FLOW
+	runningEffectName = running
 	atmosphereCurve
  	{
    		key = 0 260

--- a/GameData/SSTU/Parts/LanderCore/LC3-POD.cfg
+++ b/GameData/SSTU/Parts/LanderCore/LC3-POD.cfg
@@ -121,14 +121,26 @@ MODULE
 	name = ModuleRCSFX
 	thrusterTransformName = SC-GEN-RCS-4A-V-ThrustTransform
 	thrusterPower = 0.5
-	resourceName = MonoPropellant
 	resourceFlowMode = STAGE_PRIORITY_FLOW
 	runningEffectName = running
+	PROPELLANT
+	{
+		name = Aerozine50
+		ratio = 1
+		DrawGauge = True
+		resourceFlowMode = STAGE_PRIORITY_FLOW
+	}
+	PROPELLANT
+	{
+		name = NTO
+		ratio = 1
+		resourceFlowMode = STAGE_PRIORITY_FLOW
+	}
 	atmosphereCurve
- 	{
-   		key = 0 260
+	{
+		key = 0 280
 		key = 1 100
- 	}
+	}
 }
 MODULE
 {
@@ -270,8 +282,7 @@ MODULE
 		tankageMass = 0
 		ecHasMass = false
 		defaultModifier = standard
-		defaultResources = MonoPropellant,1;ElectricCharge,12
-		resource = MonoPropellant
+		defaultResources = NTO,2;Aerozine50,2;ElectricCharge,24
 		resource = Aerozine50
 		resource = NTO
 		resource = ElectricCharge

--- a/GameData/SSTU/Parts/LanderCore/LC5-POD.cfg
+++ b/GameData/SSTU/Parts/LanderCore/LC5-POD.cfg
@@ -122,14 +122,27 @@ MODULE
 	name = ModuleRCSFX
 	thrusterTransformName = SC-GEN-RCS-4A-V-ThrustTransform
 	thrusterPower = 0.5
-	resourceName = MonoPropellant
 	resourceFlowMode = STAGE_PRIORITY_FLOW
 	runningEffectName = running
 	atmosphereCurve
- 	{
-   		key = 0 260
+	PROPELLANT
+	{
+		name = Aerozine50
+		ratio = 1
+		DrawGauge = True
+		resourceFlowMode = STAGE_PRIORITY_FLOW
+	}
+	PROPELLANT
+	{
+		name = NTO
+		ratio = 1
+		resourceFlowMode = STAGE_PRIORITY_FLOW
+	}
+	atmosphereCurve
+	{
+		key = 0 280
 		key = 1 100
- 	}
+	}
 }
 MODULE
 {
@@ -271,8 +284,7 @@ MODULE
 		tankageMass = 0
 		ecHasMass = false
 		defaultModifier = standard
-		defaultResources = MonoPropellant,1;ElectricCharge,12
-		resource = MonoPropellant
+		defaultResources = NTO,2;Aerozine50,2;ElectricCharge,24
 		resource = Aerozine50
 		resource = NTO
 		resource = ElectricCharge

--- a/GameData/SSTU/Parts/LanderCore/LC5-POD.cfg
+++ b/GameData/SSTU/Parts/LanderCore/LC5-POD.cfg
@@ -13,6 +13,37 @@ title = SSTU - LC5-POD
 manufacturer = SSTU
 description = LC5-POD
 
+EFFECTS
+{
+	running
+	{
+		AUDIO_MULTI_POOL
+		{
+			channel = Ship
+			transformName = SC-GEN-RCS-4A-V-ThrustTransform
+			clip = sound_rocket_mini
+			volume = 0.0 0.0
+			volume = 0.1 0.0
+			volume = 0.5 0.025
+			volume = 1.0 0.1
+			pitch = 0.0 0.75
+			pitch = 1.0 1.5
+			loop = true
+		}
+		MODEL_MULTI_PARTICLE
+		{
+			modelName = Squad/FX/Monoprop_small
+			transformName = SC-GEN-RCS-4A-V-ThrustTransform
+			emission = 0.0 0.0
+			emission = 0.1 0.0
+			emission = 1.0 1.0
+			speed = 0.0 0.8
+			speed = 1.0 1.0
+			localRotation = -90, 0, 0
+		}
+	}		
+}
+
 MODEL
 {
 	model = SSTU/Assets/LC5-POD
@@ -88,11 +119,12 @@ MODULE
 }
 MODULE
 {
-	name = ModuleRCS
+	name = ModuleRCSFX
 	thrusterTransformName = SC-GEN-RCS-4A-V-ThrustTransform
 	thrusterPower = 0.5
 	resourceName = MonoPropellant
 	resourceFlowMode = STAGE_PRIORITY_FLOW
+	runningEffectName = running
 	atmosphereCurve
  	{
    		key = 0 260

--- a/GameData/SSTU/Parts/ShipCore/General/Rcs/SC-GEN-RCS-4A-V.cfg
+++ b/GameData/SSTU/Parts/ShipCore/General/Rcs/SC-GEN-RCS-4A-V.cfg
@@ -71,13 +71,25 @@ MODULE
 	stagingEnabled = False
 	thrusterTransformName = SC-GEN-RCS-4A-V-ThrustTransform
 	thrusterPower = 1
-	resourceName = MonoPropellant
 	resourceFlowMode = STAGE_PRIORITY_FLOW
 	runningEffectName = running
+	PROPELLANT
+	{
+		name = Aerozine50
+		ratio = 1
+		DrawGauge = True
+		resourceFlowMode = STAGE_PRIORITY_FLOW
+	}
+	PROPELLANT
+	{
+		name = NTO
+		ratio = 1
+		resourceFlowMode = STAGE_PRIORITY_FLOW
+	}
 	atmosphereCurve
- 	{
-   	 key = 0 260
-  	 key = 1 100
- 	}
+	{
+		key = 0 280
+		key = 1 100
+	}
 }
 }

--- a/GameData/SSTU/Parts/ShipCore/General/Rcs/SC-GEN-RCS-4A-V.cfg
+++ b/GameData/SSTU/Parts/ShipCore/General/Rcs/SC-GEN-RCS-4A-V.cfg
@@ -33,13 +33,47 @@ crashTolerance = 6
 maxTemp = 1200
 bulkheadProfiles=srf
 
+EFFECTS
+{
+	running
+	{
+		AUDIO_MULTI_POOL
+		{
+			channel = Ship
+			transformName = SC-GEN-RCS-4A-V-ThrustTransform
+			clip = sound_rocket_mini
+			volume = 0.0 0.0
+			volume = 0.1 0.0
+			volume = 0.5 0.025
+			volume = 1.0 0.1
+			pitch = 0.0 0.75
+			pitch = 1.0 1.5
+			loop = true
+		}
+		MODEL_MULTI_PARTICLE
+		{
+			modelName = Squad/FX/Monoprop_small
+			transformName = SC-GEN-RCS-4A-V-ThrustTransform
+			emission = 0.0 0.0
+			emission = 0.1 0.0
+			emission = 1.0 1.0
+			speed = 0.0 0.8
+			speed = 1.0 1.0
+			localRotation = -90, 0, 0
+		}
+	}		
+}
+	
+
 MODULE
 {
-	name = ModuleRCS
+	name = ModuleRCSFX
+	stagingEnabled = False
 	thrusterTransformName = SC-GEN-RCS-4A-V-ThrustTransform
 	thrusterPower = 1
 	resourceName = MonoPropellant
 	resourceFlowMode = STAGE_PRIORITY_FLOW
+	runningEffectName = running
 	atmosphereCurve
  	{
    	 key = 0 260
@@ -47,4 +81,3 @@ MODULE
  	}
 }
 }
-

--- a/GameData/SSTU/Parts/ShipCore/General/Rcs/SC-GEN-RCS-4F-T.cfg
+++ b/GameData/SSTU/Parts/ShipCore/General/Rcs/SC-GEN-RCS-4F-T.cfg
@@ -71,13 +71,25 @@ MODULE
 	stagingEnabled = False
 	thrusterTransformName = SC-GEN-RCS-4F-T-ThrustTransform
 	thrusterPower = 1
-	resourceName = MonoPropellant
 	resourceFlowMode = STAGE_PRIORITY_FLOW
 	runningEffectName = running
+	PROPELLANT
+	{
+		name = Aerozine50
+		ratio = 1
+		DrawGauge = True
+		resourceFlowMode = STAGE_PRIORITY_FLOW
+	}
+	PROPELLANT
+	{
+		name = NTO
+		ratio = 1
+		resourceFlowMode = STAGE_PRIORITY_FLOW
+	}
 	atmosphereCurve
- 	{
-   	 key = 0 260
-  	 key = 1 100
- 	}
+	{
+		key = 0 280
+		key = 1 100
+	}
 }
 }

--- a/GameData/SSTU/Parts/ShipCore/General/Rcs/SC-GEN-RCS-4F-T.cfg
+++ b/GameData/SSTU/Parts/ShipCore/General/Rcs/SC-GEN-RCS-4F-T.cfg
@@ -33,13 +33,47 @@ crashTolerance = 6
 maxTemp = 1200
 bulkheadProfiles=srf
 
+EFFECTS
+{
+	running
+	{
+		AUDIO_MULTI_POOL
+		{
+			channel = Ship
+			transformName = SC-GEN-RCS-4F-T-ThrustTransform
+			clip = sound_rocket_mini
+			volume = 0.0 0.0
+			volume = 0.1 0.0
+			volume = 0.5 0.025
+			volume = 1.0 0.1
+			pitch = 0.0 0.75
+			pitch = 1.0 1.5
+			loop = true
+		}
+		MODEL_MULTI_PARTICLE
+		{
+			modelName = Squad/FX/Monoprop_small
+			transformName = SC-GEN-RCS-4F-T-ThrustTransform
+			emission = 0.0 0.0
+			emission = 0.1 0.0
+			emission = 1.0 1.0
+			speed = 0.0 0.8
+			speed = 1.0 1.0
+			localRotation = -90, 0, 0
+		}
+	}		
+}
+	
+
 MODULE
 {
-	name = ModuleRCS
+	name = ModuleRCSFX
+	stagingEnabled = False
 	thrusterTransformName = SC-GEN-RCS-4F-T-ThrustTransform
 	thrusterPower = 1
 	resourceName = MonoPropellant
 	resourceFlowMode = STAGE_PRIORITY_FLOW
+	runningEffectName = running
 	atmosphereCurve
  	{
    	 key = 0 260
@@ -47,4 +81,3 @@ MODULE
  	}
 }
 }
-

--- a/GameData/SSTU/Parts/ShipCore/General/Rcs/SC-GEN-RCS-4F-V.cfg
+++ b/GameData/SSTU/Parts/ShipCore/General/Rcs/SC-GEN-RCS-4F-V.cfg
@@ -33,18 +33,52 @@ crashTolerance = 6
 maxTemp = 1200
 bulkheadProfiles=srf
 
+EFFECTS
+{
+	running
+	{
+		AUDIO_MULTI_POOL
+		{
+			channel = Ship
+			transformName = SC-GEN-RCS-4A-V-ThrustTransform
+			clip = sound_rocket_mini
+			volume = 0.0 0.0
+			volume = 0.1 0.0
+			volume = 0.5 0.025
+			volume = 1.0 0.1
+			pitch = 0.0 0.75
+			pitch = 1.0 1.5
+			loop = true
+		}
+		MODEL_MULTI_PARTICLE
+		{
+			modelName = Squad/FX/Monoprop_small
+			transformName = SC-GEN-RCS-4A-V-ThrustTransform
+			emission = 0.0 0.0
+			emission = 0.1 0.0
+			emission = 1.0 1.0
+			speed = 0.0 0.8
+			speed = 1.0 1.0
+			localRotation = -90, 0, 0
+		}
+	}		
+}
 MODULE
 {
-	name = ModuleRCS
-	thrusterTransformName = SC-GEN-RCS-4F-V-ThrustTransform
+	name = ModuleRCSFX
+	stagingEnabled = False
+	thrusterTransformName = SC-GEN-RCS-4A-V-ThrustTransform
 	thrusterPower = 1
 	resourceName = MonoPropellant
 	resourceFlowMode = STAGE_PRIORITY_FLOW
+	runningEffectName = running
 	atmosphereCurve
  	{
    	 key = 0 260
   	 key = 1 100
+	 key = 4 0.001
  	}
 }
+
 }
 

--- a/GameData/SSTU/Parts/ShipCore/General/Rcs/SC-GEN-RCS-4F-V.cfg
+++ b/GameData/SSTU/Parts/ShipCore/General/Rcs/SC-GEN-RCS-4F-V.cfg
@@ -69,14 +69,26 @@ MODULE
 	stagingEnabled = False
 	thrusterTransformName = SC-GEN-RCS-4F-V-ThrustTransform
 	thrusterPower = 1
-	resourceName = MonoPropellant
 	resourceFlowMode = STAGE_PRIORITY_FLOW
 	runningEffectName = running
+	PROPELLANT
+	{
+		name = Aerozine50
+		ratio = 1
+		DrawGauge = True
+		resourceFlowMode = STAGE_PRIORITY_FLOW
+	}
+	PROPELLANT
+	{
+		name = NTO
+		ratio = 1
+		resourceFlowMode = STAGE_PRIORITY_FLOW
+	}
 	atmosphereCurve
- 	{
-   	 key = 0 260
-  	 key = 1 100
- 	}
+	{
+		key = 0 280
+		key = 1 100
+	}
 }
 
 }

--- a/GameData/SSTU/Parts/ShipCore/General/Rcs/SC-GEN-RCS-4F-V.cfg
+++ b/GameData/SSTU/Parts/ShipCore/General/Rcs/SC-GEN-RCS-4F-V.cfg
@@ -40,7 +40,7 @@ EFFECTS
 		AUDIO_MULTI_POOL
 		{
 			channel = Ship
-			transformName = SC-GEN-RCS-4A-V-ThrustTransform
+			transformName = SC-GEN-RCS-4F-V-ThrustTransform
 			clip = sound_rocket_mini
 			volume = 0.0 0.0
 			volume = 0.1 0.0
@@ -53,7 +53,7 @@ EFFECTS
 		MODEL_MULTI_PARTICLE
 		{
 			modelName = Squad/FX/Monoprop_small
-			transformName = SC-GEN-RCS-4A-V-ThrustTransform
+			transformName = SC-GEN-RCS-4F-V-ThrustTransform
 			emission = 0.0 0.0
 			emission = 0.1 0.0
 			emission = 1.0 1.0
@@ -67,7 +67,7 @@ MODULE
 {
 	name = ModuleRCSFX
 	stagingEnabled = False
-	thrusterTransformName = SC-GEN-RCS-4A-V-ThrustTransform
+	thrusterTransformName = SC-GEN-RCS-4F-V-ThrustTransform
 	thrusterPower = 1
 	resourceName = MonoPropellant
 	resourceFlowMode = STAGE_PRIORITY_FLOW
@@ -76,7 +76,6 @@ MODULE
  	{
    	 key = 0 260
   	 key = 1 100
-	 key = 4 0.001
  	}
 }
 

--- a/GameData/SSTU/Parts/ShipCore/General/Rcs/SC-GEN-RCS-5F-V.cfg
+++ b/GameData/SSTU/Parts/ShipCore/General/Rcs/SC-GEN-RCS-5F-V.cfg
@@ -33,13 +33,46 @@ crashTolerance = 6
 maxTemp = 1200
 bulkheadProfiles=srf
 
+EFFECTS
+{
+	running
+	{
+		AUDIO_MULTI_POOL
+		{
+			channel = Ship
+			transformName = SC-GEN-RCS-5F-V-ThrustTransform
+			clip = sound_rocket_mini
+			volume = 0.0 0.0
+			volume = 0.1 0.0
+			volume = 0.5 0.025
+			volume = 1.0 0.1
+			pitch = 0.0 0.75
+			pitch = 1.0 1.5
+			loop = true
+		}
+		MODEL_MULTI_PARTICLE
+		{
+			modelName = Squad/FX/Monoprop_small
+			transformName = SC-GEN-RCS-5F-V-ThrustTransform
+			emission = 0.0 0.0
+			emission = 0.1 0.0
+			emission = 1.0 1.0
+			speed = 0.0 0.8
+			speed = 1.0 1.0
+			localRotation = -90, 0, 0
+		}
+	}		
+}
 MODULE
 {
-	name = ModuleRCS
+	name = ModuleRCSFX
+	stagingEnabled = False
 	thrusterTransformName = SC-GEN-RCS-5F-V-ThrustTransform
+
 	thrusterPower = 1
 	resourceName = MonoPropellant
 	resourceFlowMode = STAGE_PRIORITY_FLOW
+	runningEffectName = running
 	atmosphereCurve
  	{
    	 key = 0 260
@@ -47,4 +80,3 @@ MODULE
  	}
 }
 }
-

--- a/GameData/SSTU/Parts/ShipCore/General/Rcs/SC-GEN-RCS-5F-V.cfg
+++ b/GameData/SSTU/Parts/ShipCore/General/Rcs/SC-GEN-RCS-5F-V.cfg
@@ -70,13 +70,25 @@ MODULE
 	thrusterTransformName = SC-GEN-RCS-5F-V-ThrustTransform
 
 	thrusterPower = 1
-	resourceName = MonoPropellant
 	resourceFlowMode = STAGE_PRIORITY_FLOW
 	runningEffectName = running
+	PROPELLANT
+	{
+		name = Aerozine50
+		ratio = 1
+		DrawGauge = True
+		resourceFlowMode = STAGE_PRIORITY_FLOW
+	}
+	PROPELLANT
+	{
+		name = NTO
+		ratio = 1
+		resourceFlowMode = STAGE_PRIORITY_FLOW
+	}
 	atmosphereCurve
- 	{
-   	 key = 0 260
-  	 key = 1 100
- 	}
+	{
+		key = 0 280
+		key = 1 100
+	}
 }
 }

--- a/GameData/SSTU/Parts/ShipCore/General/Rcs/SC-GEN-RCS-6A-T.cfg
+++ b/GameData/SSTU/Parts/ShipCore/General/Rcs/SC-GEN-RCS-6A-T.cfg
@@ -70,14 +70,26 @@ MODULE
 	thrusterTransformName = SC-GEN-RCS-6A-T-ThrustTransform
 
 	thrusterPower = 1
-	resourceName = MonoPropellant
 	resourceFlowMode = STAGE_PRIORITY_FLOW
 	runningEffectName = running
+	PROPELLANT
+	{
+		name = Aerozine50
+		ratio = 1
+		DrawGauge = True
+		resourceFlowMode = STAGE_PRIORITY_FLOW
+	}
+	PROPELLANT
+	{
+		name = NTO
+		ratio = 1
+		resourceFlowMode = STAGE_PRIORITY_FLOW
+	}
 	atmosphereCurve
- 	{
-   	 key = 0 260
-  	 key = 1 100
- 	}
+	{
+		key = 0 280
+		key = 1 100
+	}
 }
 }
 

--- a/GameData/SSTU/Parts/ShipCore/General/Rcs/SC-GEN-RCS-6A-T.cfg
+++ b/GameData/SSTU/Parts/ShipCore/General/Rcs/SC-GEN-RCS-6A-T.cfg
@@ -33,13 +33,46 @@ crashTolerance = 6
 maxTemp = 1200
 bulkheadProfiles=srf
 
+EFFECTS
+{
+	running
+	{
+		AUDIO_MULTI_POOL
+		{
+			channel = Ship
+			transformName = SC-GEN-RCS-6A-T-ThrustTransform
+			clip = sound_rocket_mini
+			volume = 0.0 0.0
+			volume = 0.1 0.0
+			volume = 0.5 0.025
+			volume = 1.0 0.1
+			pitch = 0.0 0.75
+			pitch = 1.0 1.5
+			loop = true
+		}
+		MODEL_MULTI_PARTICLE
+		{
+			modelName = Squad/FX/Monoprop_small
+			transformName = SC-GEN-RCS-6A-T-ThrustTransform
+			emission = 0.0 0.0
+			emission = 0.1 0.0
+			emission = 1.0 1.0
+			speed = 0.0 0.8
+			speed = 1.0 1.0
+			localRotation = -90, 0, 0
+		}
+	}		
+}
 MODULE
 {
-	name = ModuleRCS
+	name = ModuleRCSFX
+	stagingEnabled = False
 	thrusterTransformName = SC-GEN-RCS-6A-T-ThrustTransform
+
 	thrusterPower = 1
 	resourceName = MonoPropellant
 	resourceFlowMode = STAGE_PRIORITY_FLOW
+	runningEffectName = running
 	atmosphereCurve
  	{
    	 key = 0 260

--- a/GameData/SSTU/Parts/ShipCore/General/Rcs/SC-GEN-RCS-8A-T.cfg
+++ b/GameData/SSTU/Parts/ShipCore/General/Rcs/SC-GEN-RCS-8A-T.cfg
@@ -69,13 +69,25 @@ MODULE
 	stagingEnabled = False
 	thrusterTransformName = SC-GEN-RCS-8A-T-ThrustTransform
 	thrusterPower = 1
-	resourceName = MonoPropellant
 	resourceFlowMode = STAGE_PRIORITY_FLOW
 	runningEffectName = running
+	PROPELLANT
+	{
+		name = Aerozine50
+		ratio = 1
+		DrawGauge = True
+		resourceFlowMode = STAGE_PRIORITY_FLOW
+	}
+	PROPELLANT
+	{
+		name = NTO
+		ratio = 1
+		resourceFlowMode = STAGE_PRIORITY_FLOW
+	}
 	atmosphereCurve
- 	{
-   	 key = 0 260
-  	 key = 1 100
- 	}
+	{
+		key = 0 280
+		key = 1 100
+	}
 }
 }

--- a/GameData/SSTU/Parts/ShipCore/General/Rcs/SC-GEN-RCS-8A-T.cfg
+++ b/GameData/SSTU/Parts/ShipCore/General/Rcs/SC-GEN-RCS-8A-T.cfg
@@ -33,13 +33,45 @@ crashTolerance = 6
 maxTemp = 1200
 bulkheadProfiles=srf
 
+EFFECTS
+{
+	running
+	{
+		AUDIO_MULTI_POOL
+		{
+			channel = Ship
+			transformName = SC-GEN-RCS-8A-T-ThrustTransform
+			clip = sound_rocket_mini
+			volume = 0.0 0.0
+			volume = 0.1 0.0
+			volume = 0.5 0.025
+			volume = 1.0 0.1
+			pitch = 0.0 0.75
+			pitch = 1.0 1.5
+			loop = true
+		}
+		MODEL_MULTI_PARTICLE
+		{
+			modelName = Squad/FX/Monoprop_small
+			transformName = SC-GEN-RCS-8A-T-ThrustTransform
+			emission = 0.0 0.0
+			emission = 0.1 0.0
+			emission = 1.0 1.0
+			speed = 0.0 0.8
+			speed = 1.0 1.0
+			localRotation = -90, 0, 0
+		}
+	}		
+}
 MODULE
 {
-	name = ModuleRCS
+	name = ModuleRCSFX
+	stagingEnabled = False
 	thrusterTransformName = SC-GEN-RCS-8A-T-ThrustTransform
 	thrusterPower = 1
 	resourceName = MonoPropellant
 	resourceFlowMode = STAGE_PRIORITY_FLOW
+	runningEffectName = running
 	atmosphereCurve
  	{
    	 key = 0 260
@@ -47,4 +79,3 @@ MODULE
  	}
 }
 }
-

--- a/GameData/SSTU/Parts/ShipCore/Series-A/SC-A-SM.cfg
+++ b/GameData/SSTU/Parts/ShipCore/Series-A/SC-A-SM.cfg
@@ -100,6 +100,61 @@ EFFECTS
 			pitch = 2.0
 			loop = false
 		}
+
+	}
+	rcs_1
+	{
+		AUDIO_MULTI_POOL
+		{
+			channel = Ship
+			transformName = SC-C-SM-RCSThrustTransform
+			clip = sound_rocket_mini
+			volume = 0.0 0.0
+			volume = 0.1 0.0
+			volume = 0.5 0.025
+			volume = 1.0 0.1
+			pitch = 0.0 0.75
+			pitch = 1.0 1.5
+			loop = true
+		}
+		MODEL_MULTI_PARTICLE
+		{
+			modelName = Squad/FX/Monoprop_small
+			transformName = SC-C-SM-RCSThrustTransform
+			emission = 0.0 0.0
+			emission = 0.1 0.0
+			emission = 1.0 1.0
+			speed = 0.0 0.8
+			speed = 1.0 1.0
+			localRotation = -90, 0, 0
+		}
+	}
+	rcs_2
+	{
+		AUDIO_MULTI_POOL
+		{
+			channel = Ship
+			transformName = SC-C-SM-RCSThrustTransform2
+			clip = sound_rocket_mini
+			volume = 0.0 0.0
+			volume = 0.1 0.0
+			volume = 0.5 0.025
+			volume = 1.0 0.1
+			pitch = 0.0 0.75
+			pitch = 1.0 1.5
+			loop = true
+		}
+		MODEL_MULTI_PARTICLE
+		{
+			modelName = Squad/FX/Monoprop_small
+			transformName = SC-C-SM-RCSThrustTransform2
+			emission = 0.0 0.0
+			emission = 0.1 0.0
+			emission = 1.0 1.0
+			speed = 0.0 0.8
+			speed = 1.0 1.0
+			localRotation = -90, 0, 0
+		}
 	}
 }
 
@@ -176,7 +231,9 @@ MODULE
 }
 MODULE
 {
-	name = ModuleRCS
+	name = ModuleRCSFX
+	runningEffectName = rcs_1
+	stagingEnabled = False
 	thrusterTransformName = SC-C-SM-RCSThrustTransform
 	enableRoll = true
 	enableYaw = false
@@ -207,7 +264,9 @@ MODULE
 }
 MODULE
 {
-	name = ModuleRCS
+	name = ModuleRCSFX
+	runningEffectName = rcs_2
+	stagingEnabled = False
 	thrusterTransformName = SC-C-SM-RCSThrustTransform2
 	enableRoll = false
 	enableYaw = true

--- a/GameData/SSTU/Parts/ShipCore/Series-A/SC-A-SM.cfg
+++ b/GameData/SSTU/Parts/ShipCore/Series-A/SC-A-SM.cfg
@@ -200,10 +200,10 @@ MODULE
 		resourceFlowMode = NO_FLOW
 	}
 	atmosphereCurve
- 	{
-   		key = 0 260
+	{
+		key = 0 280
 		key = 1 100
- 	}
+	}
 }
 MODULE
 {
@@ -231,10 +231,10 @@ MODULE
 		resourceFlowMode = NO_FLOW
 	}
 	atmosphereCurve
- 	{
-   		key = 0 260
+	{
+		key = 0 280
 		key = 1 100
- 	}
+	}
 }
 MODULE
 { 

--- a/GameData/SSTU/Parts/ShipCore/Series-A/SC-A-SMX.cfg
+++ b/GameData/SSTU/Parts/ShipCore/Series-A/SC-A-SMX.cfg
@@ -203,10 +203,10 @@ MODULE
 		resourceFlowMode = NO_FLOW
 	}
 	atmosphereCurve
- 	{
-   		key = 0 260
+	{
+		key = 0 280
 		key = 1 100
- 	}
+	}
 }
 MODULE
 {
@@ -234,10 +234,10 @@ MODULE
 		resourceFlowMode = NO_FLOW
 	}
 	atmosphereCurve
- 	{
-   		key = 0 260
+	{
+		key = 0 280
 		key = 1 100
- 	}
+	}
 }
 MODULE
 {

--- a/GameData/SSTU/Parts/ShipCore/Series-A/SC-A-SMX.cfg
+++ b/GameData/SSTU/Parts/ShipCore/Series-A/SC-A-SMX.cfg
@@ -123,6 +123,60 @@ EFFECTS
 			loop = false
 		}
 	}
+	rcs_1
+	{
+		AUDIO_MULTI_POOL
+		{
+			channel = Ship
+			transformName = SC-C-SM-RCSThrustTransform
+			clip = sound_rocket_mini
+			volume = 0.0 0.0
+			volume = 0.1 0.0
+			volume = 0.5 0.025
+			volume = 1.0 0.1
+			pitch = 0.0 0.75
+			pitch = 1.0 1.5
+			loop = true
+		}
+		MODEL_MULTI_PARTICLE
+		{
+			modelName = Squad/FX/Monoprop_small
+			transformName = SC-C-SM-RCSThrustTransform
+			emission = 0.0 0.0
+			emission = 0.1 0.0
+			emission = 1.0 1.0
+			speed = 0.0 0.8
+			speed = 1.0 1.0
+			localRotation = -90, 0, 0
+		}
+	}
+	rcs_2
+	{
+		AUDIO_MULTI_POOL
+		{
+			channel = Ship
+			transformName = SC-C-SM-RCSThrustTransform2
+			clip = sound_rocket_mini
+			volume = 0.0 0.0
+			volume = 0.1 0.0
+			volume = 0.5 0.025
+			volume = 1.0 0.1
+			pitch = 0.0 0.75
+			pitch = 1.0 1.5
+			loop = true
+		}
+		MODEL_MULTI_PARTICLE
+		{
+			modelName = Squad/FX/Monoprop_small
+			transformName = SC-C-SM-RCSThrustTransform2
+			emission = 0.0 0.0
+			emission = 0.1 0.0
+			emission = 1.0 1.0
+			speed = 0.0 0.8
+			speed = 1.0 1.0
+			localRotation = -90, 0, 0
+		}
+	}
 }
 
 MODULE
@@ -179,7 +233,9 @@ MODULE
 }
 MODULE
 {
-	name = ModuleRCS
+	name = ModuleRCSFX
+	runningEffectName = rcs_1
+	stagingEnabled = False
 	thrusterTransformName = SC-C-SM-RCSThrustTransform
 	enableRoll = true
 	enableYaw = false
@@ -210,7 +266,9 @@ MODULE
 }
 MODULE
 {
-	name = ModuleRCS
+	name = ModuleRCSFX
+	runningEffectName = rcs_2
+	stagingEnabled = False
 	thrusterTransformName = SC-C-SM-RCSThrustTransform2
 	enableRoll = false
 	enableYaw = true

--- a/GameData/SSTU/Parts/ShipCore/Series-B/SC-B-CM.cfg
+++ b/GameData/SSTU/Parts/ShipCore/Series-B/SC-B-CM.cfg
@@ -275,11 +275,44 @@ MODULE
 		rate = 0.6
 	}
 }
+EFFECTS
+{
+	running
+	{
+		AUDIO
+		{
+			channel = Ship
+			transformName = SC-A-CM-RCSThrustTransform
+			clip = sound_rocket_mini
+			volume = 0.0 0.0
+			volume = 0.1 0.0
+			volume = 0.5 0.05
+			volume = 1.0 0.5
+			pitch = 0.0 0.5
+			pitch = 1.0 1.0
+			loop = true
+		}
+		MODEL_MULTI_PARTICLE
+		{
+			modelName = Squad/FX/Monoprop_medium
+			transformName = SC-A-CM-RCSThrustTransform
+			emission = 0.0 0.0
+			emission = 0.1 0.0
+			emission = 1.0 1.0
+			speed = 0.0 0.8
+			speed = 1.0 1.0
+			localRotation = -90, 0, 0
+		}
+	}		
+}
+
 MODULE
 {
-	name = ModuleRCS
+	name = ModuleRCSFX
+	stagingEnabled = False
 	thrusterTransformName = SC-A-CM-RCSThrustTransform
 	thrusterPower = 1
+	runningEffectName = running
 	PROPELLANT
 	{
 		name = Aerozine50
@@ -299,6 +332,7 @@ MODULE
 		key = 1 100
  	}
 }
+
 MODULE
 {
 	name = ModuleScienceExperiment		

--- a/GameData/SSTU/Parts/ShipCore/Series-B/SC-B-CM.cfg
+++ b/GameData/SSTU/Parts/ShipCore/Series-B/SC-B-CM.cfg
@@ -327,10 +327,10 @@ MODULE
 		resourceFlowMode = NO_FLOW
 	}
 	atmosphereCurve
- 	{
-   		key = 0 260
+	{
+		key = 0 280
 		key = 1 100
- 	}
+	}
 }
 
 MODULE

--- a/GameData/SSTU/Parts/ShipCore/Series-B/SC-B-CM.cfg
+++ b/GameData/SSTU/Parts/ShipCore/Series-B/SC-B-CM.cfg
@@ -14,6 +14,37 @@ manufacturer = SSTU
 description = SSTU - ShipCore: Series B - Re-Entry Module.  This fully equipped command module seats 3 Kerbals and is capable of direct-re-entry from Mun or Minmus orbit.  Equipped with SAS, reaction wheel, parachutes, RCS, docking port, docking lights, cabin lighting, batteries, short-range transmitter, decoupler, and heat-shield.
 tags = crew, pod, cm, reentry, )chute, para, transmitter, antenna, dock, port
 
+EFFECTS
+{
+	running
+	{
+		AUDIO
+		{
+			channel = Ship
+			transformName = SC-A-CM-RCSThrustTransform
+			clip = sound_rocket_mini
+			volume = 0.0 0.0
+			volume = 0.1 0.0
+			volume = 0.5 0.025
+			volume = 1.0 0.1
+			pitch = 0.0 0.75
+			pitch = 1.0 1.5
+			loop = true
+		}
+		MODEL_MULTI_PARTICLE
+		{
+			modelName = Squad/FX/Monoprop_small
+			transformName = SC-A-CM-RCSThrustTransform
+			emission = 0.0 0.0
+			emission = 0.1 0.0
+			emission = 1.0 1.0
+			speed = 0.0 0.8
+			speed = 1.0 1.0
+			localRotation = -90, 0, 0
+		}
+	}		
+}
+
 MODEL
 {
 	model = SSTU/Assets/SC-B-CM
@@ -275,37 +306,6 @@ MODULE
 		rate = 0.6
 	}
 }
-EFFECTS
-{
-	running
-	{
-		AUDIO
-		{
-			channel = Ship
-			transformName = SC-A-CM-RCSThrustTransform
-			clip = sound_rocket_mini
-			volume = 0.0 0.0
-			volume = 0.1 0.0
-			volume = 0.5 0.05
-			volume = 1.0 0.5
-			pitch = 0.0 0.5
-			pitch = 1.0 1.0
-			loop = true
-		}
-		MODEL_MULTI_PARTICLE
-		{
-			modelName = Squad/FX/Monoprop_medium
-			transformName = SC-A-CM-RCSThrustTransform
-			emission = 0.0 0.0
-			emission = 0.1 0.0
-			emission = 1.0 1.0
-			speed = 0.0 0.8
-			speed = 1.0 1.0
-			localRotation = -90, 0, 0
-		}
-	}		
-}
-
 MODULE
 {
 	name = ModuleRCSFX

--- a/GameData/SSTU/Parts/ShipCore/Series-B/SC-B-CMX.cfg
+++ b/GameData/SSTU/Parts/ShipCore/Series-B/SC-B-CMX.cfg
@@ -148,10 +148,10 @@ MODULE
 		resourceFlowMode = NO_FLOW
 	}
 	atmosphereCurve
- 	{
-   		key = 0 260
+	{
+		key = 0 280
 		key = 1 100
- 	}
+	}
 }
 MODULE
 {

--- a/GameData/SSTU/Parts/ShipCore/Series-B/SC-B-CMX.cfg
+++ b/GameData/SSTU/Parts/ShipCore/Series-B/SC-B-CMX.cfg
@@ -51,6 +51,36 @@ vesselType = Ship
 CrewCapacity = 3
 bulkheadProfiles = size2, size0
 
+EFFECTS
+{
+	running
+	{
+		AUDIO
+		{
+			channel = Ship
+			transformName = SC-A-CM-RCSThrustTransform
+			clip = sound_rocket_mini
+			volume = 0.0 0.0
+			volume = 0.1 0.0
+			volume = 0.5 0.025
+			volume = 1.0 0.1
+			pitch = 0.0 0.75
+			pitch = 1.0 1.5
+			loop = true
+		}
+		MODEL_MULTI_PARTICLE
+		{
+			modelName = Squad/FX/Monoprop_small
+			transformName = SC-A-CM-RCSThrustTransform
+			emission = 0.0 0.0
+			emission = 0.1 0.0
+			emission = 1.0 1.0
+			speed = 0.0 0.8
+			speed = 1.0 1.0
+			localRotation = -90, 0, 0
+		}
+	}		
+}
 
 RESOURCE
 {
@@ -99,9 +129,11 @@ MODULE
 }
 MODULE
 {
-	name = ModuleRCS
+	name = ModuleRCSFX
+	stagingEnabled = False
 	thrusterTransformName = SC-A-CM-RCSThrustTransform
 	thrusterPower = 1
+	runningEffectName = running
 	PROPELLANT
 	{
 		name = Aerozine50

--- a/GameData/SSTU/Parts/ShipCore/Series-B/SC-B-SM.cfg
+++ b/GameData/SSTU/Parts/ShipCore/Series-B/SC-B-SM.cfg
@@ -254,7 +254,6 @@ MODULE
 	stagingEnabled = False
 	thrusterTransformName = SC-GEN-RCS-4F-V-ThrustTransform
 	thrusterPower = 1
-	resourceFlowMode = STAGE_PRIORITY_FLOW
 	runningEffectName = running
 	PROPELLANT
 	{

--- a/GameData/SSTU/Parts/ShipCore/Series-B/SC-B-SM.cfg
+++ b/GameData/SSTU/Parts/ShipCore/Series-B/SC-B-SM.cfg
@@ -102,7 +102,7 @@ EFFECTS
 		MODEL_MULTI_PARTICLE
 		{
 			modelName = Squad/FX/ksX_Exhaust
-			transformName = SC-A-SM-ThrustTransform			
+			transformName = SC-A-SM-ThrustTransform		
 			emission = 0.0 0.0
 			emission = 0.05 0.0
 			emission = 0.075 0.0625
@@ -140,6 +140,34 @@ EFFECTS
 			loop = false
 		}
 	}
+	running
+	{
+		AUDIO_MULTI_POOL
+		{
+			channel = Ship
+			transformName = SC-GEN-RCS-4F-V-ThrustTransform
+			clip = sound_rocket_mini
+			volume = 0.0 0.0
+			volume = 0.1 0.0
+			volume = 0.5 0.025
+			volume = 1.0 0.1
+			pitch = 0.0 0.75
+			pitch = 1.0 1.5
+			loop = true
+		}
+		MODEL_MULTI_PARTICLE
+		{
+			modelName = Squad/FX/Monoprop_small
+			transformName = SC-GEN-RCS-4F-V-ThrustTransform
+			emission = 0.0 0.0
+			emission = 0.1 0.0
+			emission = 1.0 1.0
+			speed = 0.0 0.8
+			speed = 1.0 1.0
+			localRotation = -90, 0, 0
+		}
+	}		
+
 }
 
 
@@ -221,9 +249,13 @@ MODULE
 }
 MODULE
 {
-	name = ModuleRCS
+	name = ModuleRCSFX
+	runningEffectName = running
+	stagingEnabled = False
 	thrusterTransformName = SC-GEN-RCS-4F-V-ThrustTransform
 	thrusterPower = 1
+	resourceFlowMode = STAGE_PRIORITY_FLOW
+	runningEffectName = running
 	PROPELLANT
 	{
 		name = Aerozine50

--- a/GameData/SSTU/Parts/ShipCore/Series-B/SC-B-SM.cfg
+++ b/GameData/SSTU/Parts/ShipCore/Series-B/SC-B-SM.cfg
@@ -270,10 +270,10 @@ MODULE
 		resourceFlowMode = NO_FLOW
 	}
 	atmosphereCurve
- 	{
-   		key = 0 260
+	{
+		key = 0 280
 		key = 1 100
- 	}
+	}
 }
 MODULE
 { 

--- a/GameData/SSTU/Parts/ShipCore/Series-C/SC-C-CM.cfg
+++ b/GameData/SSTU/Parts/ShipCore/Series-C/SC-C-CM.cfg
@@ -306,10 +306,10 @@ MODULE
 		resourceFlowMode = NO_FLOW
 	}
 	atmosphereCurve
- 	{
-   		key = 0 260
+	{
+		key = 0 280
 		key = 1 100
- 	}
+	}
 }
 MODULE
 {

--- a/GameData/SSTU/Parts/ShipCore/Series-C/SC-C-CM.cfg
+++ b/GameData/SSTU/Parts/ShipCore/Series-C/SC-C-CM.cfg
@@ -14,6 +14,38 @@ manufacturer = SSTU
 description = SSTU - ShipCore: Series C - Re-Entry Module.  This fully equipped command module seats 6 Kerbals for short missions, or 4 Kerbals for longer missions.  It is intended for long term deep-space operation and includes all the comforts one would expect when travelling millions of kilometers from home.  Includes SAS, reaction wheels, RCS, docking Port, docking lights, parachutes, heat shield, short-range transmitter (WIP), and decoupler.  Heat-shield is rated for re-entry from Eve and Duna, though may be capable of more.
 tags = crew, pod, cm, reentry, )chute, para, transmitter, antenna, dock, port
 
+
+EFFECTS
+{
+	running
+	{
+		AUDIO_MULTI_POOL
+		{
+			channel = Ship
+			transformName = SC-B-CM-RCSThrustTransform
+			clip = sound_rocket_mini
+			volume = 0.0 0.0
+			volume = 0.1 0.0
+			volume = 0.5 0.025
+			volume = 1.0 0.1
+			pitch = 0.0 0.75
+			pitch = 1.0 1.5
+			loop = true
+		}
+		MODEL_MULTI_PARTICLE
+		{
+			modelName = Squad/FX/Monoprop_small
+			transformName = SC-B-CM-RCSThrustTransform
+			emission = 0.0 0.0
+			emission = 0.1 0.0
+			emission = 1.0 1.0
+			speed = 0.0 0.8
+			speed = 1.0 1.0
+			localRotation = -90, 0, 0
+		}
+	}		
+}
+
 MODEL
 {
 	model = SSTU/Assets/SC-C-CM
@@ -256,9 +288,10 @@ MODULE
 }
 MODULE
 {
-	name = ModuleRCS
+	name = ModuleRCSFX
 	thrusterTransformName = SC-B-CM-RCSThrustTransform
 	thrusterPower = 0.9
+	runningEffectName = running
 	PROPELLANT
 	{
 		name = Aerozine50

--- a/GameData/SSTU/Parts/ShipCore/Series-C/SC-C-CMX.cfg
+++ b/GameData/SSTU/Parts/ShipCore/Series-C/SC-C-CMX.cfg
@@ -14,6 +14,37 @@ manufacturer = SSTU
 description = SSTU - ShipCore: Series C - Orbital Module.  This fully equipped command module seats 6 Kerbals for short missions, or 4 Kerbals for longer missions.  It is intended for long term non-atmospheric deep-space operation and includes all the comforts one would expect when travelling millions of kilometers from home.  Includes SAS, reaction wheels, RCS, docking Port, docking lights, short-range transmitter (WIP), and decoupler.
 tags = crew, pod, cm, orbital, transmitter, antenna, dock, port
 
+EFFECTS
+{
+	running
+	{
+		AUDIO_MULTI_POOL
+		{
+			channel = Ship
+			transformName = SC-B-CM-RCSThrustTransform
+			clip = sound_rocket_mini
+			volume = 0.0 0.0
+			volume = 0.1 0.0
+			volume = 0.5 0.025
+			volume = 1.0 0.1
+			pitch = 0.0 0.75
+			pitch = 1.0 1.5
+			loop = true
+		}
+		MODEL_MULTI_PARTICLE
+		{
+			modelName = Squad/FX/Monoprop_small
+			transformName = SC-B-CM-RCSThrustTransform
+			emission = 0.0 0.0
+			emission = 0.1 0.0
+			emission = 1.0 1.0
+			speed = 0.0 0.8
+			speed = 1.0 1.0
+			localRotation = -90, 0, 0
+		}
+	}		
+}
+
 MODEL
 {
 	model = SSTU/Assets/SC-C-CMX
@@ -105,9 +136,10 @@ MODULE
 }
 MODULE
 {
-	name = ModuleRCS
+	name = ModuleRCSFX
 	thrusterTransformName = SC-B-CM-RCSThrustTransform
 	thrusterPower = 1.2
+	runningEffectName = running
 	PROPELLANT
 	{
 		name = Aerozine50

--- a/GameData/SSTU/Parts/ShipCore/Series-C/SC-C-CMX.cfg
+++ b/GameData/SSTU/Parts/ShipCore/Series-C/SC-C-CMX.cfg
@@ -154,10 +154,10 @@ MODULE
 		resourceFlowMode = NO_FLOW
 	}
 	atmosphereCurve
- 	{
-   		key = 0 260
+	{
+		key = 0 280
 		key = 1 100
- 	}
+	}
 }
 MODULE
 {

--- a/GameData/SSTU/Parts/ShipCore/Series-C/SC-C-SM.cfg
+++ b/GameData/SSTU/Parts/ShipCore/Series-C/SC-C-SM.cfg
@@ -107,6 +107,87 @@ EFFECTS
 			loop = false
 		}
 	}
+	rcs_1
+	{
+		AUDIO_MULTI_POOL
+		{
+			channel = Ship
+			transformName = SC-B-SM-RCSThrustTransform1
+			clip = sound_rocket_mini
+			volume = 0.0 0.0
+			volume = 0.1 0.0
+			volume = 0.5 0.025
+			volume = 1.0 0.1
+			pitch = 0.0 0.75
+			pitch = 1.0 1.5
+			loop = true
+		}
+		MODEL_MULTI_PARTICLE
+		{
+			modelName = Squad/FX/Monoprop_small
+			transformName = SC-B-SM-RCSThrustTransform1
+			emission = 0.0 0.0
+			emission = 0.1 0.0
+			emission = 1.0 1.0
+			speed = 0.0 0.8
+			speed = 1.0 1.0
+			localRotation = -90, 0, 0
+		}
+	}
+	rcs_2
+	{
+		AUDIO_MULTI_POOL
+		{
+			channel = Ship
+			transformName = SC-B-SM-RCSThrustTransform2
+			clip = sound_rocket_mini
+			volume = 0.0 0.0
+			volume = 0.1 0.0
+			volume = 0.5 0.025
+			volume = 1.0 0.1
+			pitch = 0.0 0.75
+			pitch = 1.0 1.5
+			loop = true
+		}
+		MODEL_MULTI_PARTICLE
+		{
+			modelName = Squad/FX/Monoprop_small
+			transformName = SC-B-SM-RCSThrustTransform2
+			emission = 0.0 0.0
+			emission = 0.1 0.0
+			emission = 1.0 1.0
+			speed = 0.0 0.8
+			speed = 1.0 1.0
+			localRotation = -90, 0, 0
+		}
+	}
+	rcs_3
+	{
+		AUDIO_MULTI_POOL
+		{
+			channel = Ship
+			transformName = SC-B-SM-RCSThrustTransform3
+			clip = sound_rocket_mini
+			volume = 0.0 0.0
+			volume = 0.1 0.0
+			volume = 0.5 0.025
+			volume = 1.0 0.1
+			pitch = 0.0 0.75
+			pitch = 1.0 1.5
+			loop = true
+		}
+		MODEL_MULTI_PARTICLE
+		{
+			modelName = Squad/FX/Monoprop_small
+			transformName = SC-B-SM-RCSThrustTransform3
+			emission = 0.0 0.0
+			emission = 0.1 0.0
+			emission = 1.0 1.0
+			speed = 0.0 0.8
+			speed = 1.0 1.0
+			localRotation = -90, 0, 0
+		}
+	}
 }
 
 RESOURCE
@@ -161,7 +242,9 @@ MODULE
 }
 MODULE
 {
-	name = ModuleRCS
+	name = ModuleRCSFX
+	runningEffectName = rcs_1
+	stagingEnabled = False
 	thrusterTransformName = SC-B-SM-RCSThrustTransform1
 	thrusterPower = 1
 	PROPELLANT
@@ -192,7 +275,9 @@ MODULE
 }
 MODULE
 {
-	name = ModuleRCS
+	name = ModuleRCSFX
+	runningEffectName = rcs_2
+	stagingEnabled = False
 	thrusterTransformName = SC-B-SM-RCSThrustTransform2
 	thrusterPower = 1
 	PROPELLANT
@@ -223,7 +308,9 @@ MODULE
 }
 MODULE
 {
-	name = ModuleRCS
+	name = ModuleRCSFX
+	runningEffectName = rcs_3
+	stagingEnabled = False
 	thrusterTransformName = SC-B-SM-ThrustTransform2
 	thrusterPower = 1
 	PROPELLANT

--- a/GameData/SSTU/Parts/ShipCore/Series-C/SC-C-SM.cfg
+++ b/GameData/SSTU/Parts/ShipCore/Series-C/SC-C-SM.cfg
@@ -166,7 +166,7 @@ EFFECTS
 		AUDIO_MULTI_POOL
 		{
 			channel = Ship
-			transformName = SC-B-SM-RCSThrustTransform3
+			transformName = SC-B-SM-RCSThrustTransform2
 			clip = sound_rocket_mini
 			volume = 0.0 0.0
 			volume = 0.1 0.0
@@ -179,7 +179,7 @@ EFFECTS
 		MODEL_MULTI_PARTICLE
 		{
 			modelName = Squad/FX/Monoprop_small
-			transformName = SC-B-SM-RCSThrustTransform3
+			transformName = SC-B-SM-RCSThrustTransform2
 			emission = 0.0 0.0
 			emission = 0.1 0.0
 			emission = 1.0 1.0

--- a/GameData/SSTU/Parts/ShipCore/Series-C/SC-C-SM.cfg
+++ b/GameData/SSTU/Parts/ShipCore/Series-C/SC-C-SM.cfg
@@ -177,6 +177,11 @@ MODULE
 		ratio = 1
 		resourceFlowMode = NO_FLOW
 	}
+	atmosphereCurve
+	{
+		key = 0 280
+		key = 1 100
+	}
 	enableRoll = true
 	enableYaw = false
 	enablePitch = false
@@ -184,11 +189,6 @@ MODULE
 	enableY = true
 	enableZ = false
 	fxPrefix = first	
-	atmosphereCurve
- 	{
-   		key = 0 260
-		key = 1 100
- 	}
 }
 MODULE
 {
@@ -208,6 +208,11 @@ MODULE
 		ratio = 1
 		resourceFlowMode = NO_FLOW
 	}
+	atmosphereCurve
+	{
+		key = 0 280
+		key = 1 100
+	}
 	enableRoll = false
 	enableYaw = true
 	enablePitch = true
@@ -215,11 +220,6 @@ MODULE
 	enableY = false
 	enableZ = true
 	fxPrefix = second
-	atmosphereCurve
- 	{
-   		key = 0 260
-		key = 1 100
- 	}
 }
 MODULE
 {
@@ -239,6 +239,11 @@ MODULE
 		ratio = 1
 		resourceFlowMode = NO_FLOW
 	}
+	atmosphereCurve
+	{
+		key = 0 280
+		key = 1 100
+	}
 	enableRoll = false
 	enableYaw = false
 	enablePitch = false
@@ -247,10 +252,6 @@ MODULE
 	enableZ = true
 	fxPrefix = third
 	atmosphereCurve
- 	{
-   		key = 0 280
-		key = 1 100
- 	}
 }
 MODULE
 { 

--- a/GameData/SSTU/Parts/StationCore/ST-DOS/ST-DOS-A.cfg
+++ b/GameData/SSTU/Parts/StationCore/ST-DOS/ST-DOS-A.cfg
@@ -110,6 +110,33 @@ EFFECTS
 			loop = false
 		}
 	}
+	running
+	{
+		AUDIO_MULTI_POOL
+		{
+			channel = Ship
+			transformName = SC-GEN-RCS-6A-T-ThrustTransform
+			clip = sound_rocket_mini
+			volume = 0.0 0.0
+			volume = 0.1 0.0
+			volume = 0.5 0.025
+			volume = 1.0 0.1
+			pitch = 0.0 0.75
+			pitch = 1.0 1.5
+			loop = true
+		}
+		MODEL_MULTI_PARTICLE
+		{
+			modelName = Squad/FX/Monoprop_small
+			transformName = SC-GEN-RCS-6A-T-ThrustTransform
+			emission = 0.0 0.0
+			emission = 0.1 0.0
+			emission = 1.0 1.0
+			speed = 0.0 0.8
+			speed = 1.0 1.0
+			localRotation = -90, 0, 0
+		}
+	}
 }
 
 MODULE
@@ -583,9 +610,10 @@ MODULE
 }
 MODULE
 {
-	name = ModuleRCS
+	name = ModuleRCSFX
 	thrusterTransformName = SC-GEN-RCS-6A-T-ThrustTransform
 	thrusterPower = 1
+	runningEffectName = running
 	PROPELLANT
 	{
 		name = Aerozine50

--- a/GameData/SSTU/Parts/StationCore/ST-HAB/ST-HAB-A.cfg
+++ b/GameData/SSTU/Parts/StationCore/ST-HAB/ST-HAB-A.cfg
@@ -13,6 +13,37 @@ title = SSTU - ST-HAB-A
 manufacturer = SSTU
 description = SSTU - StationCore - HAB-A - UNFINISHED PROTOTYPE PART - UNTEXTURED - MODEL NOT FINISHED - NOT FEATURE COMPLETE - 
 
+EFFECTS
+{
+	running
+	{
+		AUDIO_MULTI_POOL
+		{
+			channel = Ship
+			transformName = SC-GEN-RCS-6A-T-ThrustTransform
+			clip = sound_rocket_mini
+			volume = 0.0 0.0
+			volume = 0.1 0.0
+			volume = 0.5 0.025
+			volume = 1.0 0.1
+			pitch = 0.0 0.75
+			pitch = 1.0 1.5
+			loop = true
+		}
+		MODEL_MULTI_PARTICLE
+		{
+			modelName = Squad/FX/Monoprop_small
+			transformName = SC-GEN-RCS-6A-T-ThrustTransform
+			emission = 0.0 0.0
+			emission = 0.1 0.0
+			emission = 1.0 1.0
+			speed = 0.0 0.8
+			speed = 1.0 1.0
+			localRotation = -90, 0, 0
+		}
+	}
+}
+
 MODEL
 {
 	model = SSTU/Assets/EmptyProxyModel
@@ -182,9 +213,10 @@ MODULE
 }
 MODULE
 {
-	name = ModuleRCS
+	name = ModuleRCSFX
 	thrusterTransformName = SC-GEN-RCS-6A-T-ThrustTransform
 	thrusterPower = 1
+	runningEffectName = running
 	PROPELLANT
 	{
 		name = Aerozine50


### PR DESCRIPTION
Hey, I've put the two parts I've done in here, the SC-GEN-RCS-4A-V (angled single 4 way rcs), and SC-B-CM.cfg (orion reentry module).

They work fine ingame, if it looks okay to you, then I'll apply it to the others.

---

One question remains: Those EFFECT plumes use prefabs, KSP comes with two RCS plumes. It has a small white plume for monopropo, and a medium sized, yellowish plume for it's biprop rcs (stock vernour rcs):

picture: http://i.imgur.com/UIiE9Gj.png edit: better picture http://i.imgur.com/Scrtzz4.png

I think it would be cool to use both to visually reflect if a thruster uses monoprop or biprop, but that comes with a small inconsistency: The prefab size is static, so biprop plumes would _always_ be bigger than monoprop, regardless of actual thruster power (as seen in the picture).

To me that's not a problem, but it's of course your mod, so I want to ask it's fine to use both?

---
Manual conversion progress:
[x] LC-POD
[x] MRCS
[ ] MUS
[ ] MSRB
[ ] StationCore
[ ] ShipCore