### PR TITLE
Made the MinSize for the Delta IV mount as 3.125

### DIFF
--- a/GameData/SSTU/Parts/ShipCore/Engines/SC-ENG-RS-68.cfg
+++ b/GameData/SSTU/Parts/ShipCore/Engines/SC-ENG-RS-68.cfg
@@ -144,7 +144,7 @@ MODULE
 		{
 			name = Mount-Delta-IV
 			size = 3.75
-			minSize = 3.75
+			minSize = 3.125
 			maxSize = 3.75
 		}
 	}


### PR DESCRIPTION
In my testing, this allows you to create a proper Delta IV ship with the correct proportions and that will make it to orbit with good payloads. It also is not save game breaking as the 3.75 is still the default size.