### PR TITLE
SRB Efficiency Upgrades

### DIFF
--- a/GameData/SSTU/Parts/ShipCore/SRB/SC-ENG-SRB-A.cfg
+++ b/GameData/SSTU/Parts/ShipCore/SRB/SC-ENG-SRB-A.cfg
@@ -147,9 +147,53 @@ MODULE
 	}
 	atmosphereCurve
  	{
-		key = 0 220
-		key = 1 210
+		key = 0 195
+		key = 1 170
  	}
+	UPGRADES
+	{
+		UPGRADE
+		{
+			name__ = SSTU-SC-ENG-SRB-GeneralRocketry
+			description__ = Isp now 175/210
+			maxThrust = 1234.5
+			atmosphereCurve
+		 	{
+				key = 0 210
+				key = 1 175
+		 	}
+		}
+		UPGRADE
+		{
+			name__ = SSTU-SC-ENG-SRB-HeavyRocketry
+			description__ = Isp now 195/220
+			atmosphereCurve
+		 	{
+				key = 0 220
+				key = 1 195
+		 	}
+		}
+		UPGRADE
+		{
+			name__ = SSTU-SC-ENG-SRB-HeavierRocketry
+			description__ = Isp now 225/255
+			atmosphereCurve
+		 	{
+				key = 0 255
+				key = 1 225
+		 	}
+		}
+		UPGRADE
+		{
+			name__ = SSTU-SC-ENG-SRB-VeryHeavyRocketry
+			description__ = Isp now 245/270
+			atmosphereCurve
+		 	{
+				key = 0 270
+				key = 1 245
+		 	}
+		}
+	}
 }
 MODULE
 {

--- a/GameData/SSTU/Parts/ShipCore/SRB/SC-ENG-SRB-A.cfg
+++ b/GameData/SSTU/Parts/ShipCore/SRB/SC-ENG-SRB-A.cfg
@@ -2,6 +2,7 @@ PART
 {
 module = Part
 name = SSTU-SC-ENG-SRB-A
+identicalParts = SSTU-SC-ENG-SRB-B, SSTU-SC-ENG-SRB-C, SSTU-SC-ENG-SRB-D
 author = Shadowmage
 
 TechRequired = basicRocketry

--- a/GameData/SSTU/Parts/ShipCore/SRB/SC-ENG-SRB-B.cfg
+++ b/GameData/SSTU/Parts/ShipCore/SRB/SC-ENG-SRB-B.cfg
@@ -2,6 +2,7 @@ PART
 {
 module = Part
 name = SSTU-SC-ENG-SRB-B
+identicalParts = SSTU-SC-ENG-SRB-A, SSTU-SC-ENG-SRB-C, SSTU-SC-ENG-SRB-D
 author = Shadowmage
 
 TechRequired = basicRocketry

--- a/GameData/SSTU/Parts/ShipCore/SRB/SC-ENG-SRB-B.cfg
+++ b/GameData/SSTU/Parts/ShipCore/SRB/SC-ENG-SRB-B.cfg
@@ -147,9 +147,52 @@ MODULE
 	}
 	atmosphereCurve
  	{
-		key = 0 220
-		key = 1 210
+		key = 0 195
+		key = 1 170
  	}
+	UPGRADES
+	{
+		UPGRADE
+		{
+			name__ = SSTU-SC-ENG-SRB-GeneralRocketry
+			description__ = Isp now 175/210
+			atmosphereCurve
+		 	{
+				key = 0 210
+				key = 1 175
+		 	}
+		}
+		UPGRADE
+		{
+			name__ = SSTU-SC-ENG-SRB-HeavyRocketry
+			description__ = Isp now 195/220
+			atmosphereCurve
+		 	{
+				key = 0 220
+				key = 1 195
+		 	}
+		}
+		UPGRADE
+		{
+			name__ = SSTU-SC-ENG-SRB-HeavierRocketry
+			description__ = Isp now 225/255
+			atmosphereCurve
+		 	{
+				key = 0 255
+				key = 1 225
+		 	}
+		}
+		UPGRADE
+		{
+			name__ = SSTU-SC-ENG-SRB-VeryHeavyRocketry
+			description__ = Isp now 245/270
+			atmosphereCurve
+		 	{
+				key = 0 270
+				key = 1 245
+		 	}
+		}
+	}
 }
 MODULE
 {

--- a/GameData/SSTU/Parts/ShipCore/SRB/SC-ENG-SRB-C.cfg
+++ b/GameData/SSTU/Parts/ShipCore/SRB/SC-ENG-SRB-C.cfg
@@ -147,9 +147,52 @@ MODULE
 	}
 	atmosphereCurve
  	{
-		key = 0 220
-		key = 1 210
+		key = 0 195
+		key = 1 170
  	}
+	UPGRADES
+	{
+		UPGRADE
+		{
+			name__ = SSTU-SC-ENG-SRB-GeneralRocketry
+			description__ = Isp now 175/210
+			atmosphereCurve
+		 	{
+				key = 0 210
+				key = 1 175
+		 	}
+		}
+		UPGRADE
+		{
+			name__ = SSTU-SC-ENG-SRB-HeavyRocketry
+			description__ = Isp now 195/220
+			atmosphereCurve
+		 	{
+				key = 0 220
+				key = 1 195
+		 	}
+		}
+		UPGRADE
+		{
+			name__ = SSTU-SC-ENG-SRB-HeavierRocketry
+			description__ = Isp now 225/255
+			atmosphereCurve
+		 	{
+				key = 0 255
+				key = 1 225
+		 	}
+		}
+		UPGRADE
+		{
+			name__ = SSTU-SC-ENG-SRB-VeryHeavyRocketry
+			description__ = Isp now 245/270
+			atmosphereCurve
+		 	{
+				key = 0 270
+				key = 1 245
+		 	}
+		}
+	}
 }
 MODULE
 {

--- a/GameData/SSTU/Parts/ShipCore/SRB/SC-ENG-SRB-C.cfg
+++ b/GameData/SSTU/Parts/ShipCore/SRB/SC-ENG-SRB-C.cfg
@@ -2,6 +2,7 @@ PART
 {
 module = Part
 name = SSTU-SC-ENG-SRB-C
+identicalParts = SSTU-SC-ENG-SRB-A, SSTU-SC-ENG-SRB-B, SSTU-SC-ENG-SRB-D
 author = Shadowmage
 
 TechRequired = basicRocketry

--- a/GameData/SSTU/Parts/ShipCore/SRB/SC-ENG-SRB-D.cfg
+++ b/GameData/SSTU/Parts/ShipCore/SRB/SC-ENG-SRB-D.cfg
@@ -147,9 +147,52 @@ MODULE
 	}
 	atmosphereCurve
  	{
-		key = 0 220
-		key = 1 210
+		key = 0 195
+		key = 1 170
  	}
+	UPGRADES
+	{
+		UPGRADE
+		{
+			name__ = SSTU-SC-ENG-SRB-GeneralRocketry
+			description__ = Isp now 175/210
+			atmosphereCurve
+		 	{
+				key = 0 210
+				key = 1 175
+		 	}
+		}
+		UPGRADE
+		{
+			name__ = SSTU-SC-ENG-SRB-HeavyRocketry
+			description__ = Isp now 195/220
+			atmosphereCurve
+		 	{
+				key = 0 220
+				key = 1 195
+		 	}
+		}
+		UPGRADE
+		{
+			name__ = SSTU-SC-ENG-SRB-HeavierRocketry
+			description__ = Isp now 225/255
+			atmosphereCurve
+		 	{
+				key = 0 255
+				key = 1 225
+		 	}
+		}
+		UPGRADE
+		{
+			name__ = SSTU-SC-ENG-SRB-VeryHeavyRocketry
+			description__ = Isp now 245/270
+			atmosphereCurve
+		 	{
+				key = 0 270
+				key = 1 245
+		 	}
+		}
+	}
 }
 MODULE
 {

--- a/GameData/SSTU/Parts/ShipCore/SRB/SC-ENG-SRB-D.cfg
+++ b/GameData/SSTU/Parts/ShipCore/SRB/SC-ENG-SRB-D.cfg
@@ -2,6 +2,7 @@ PART
 {
 module = Part
 name = SSTU-SC-ENG-SRB-D
+identicalParts = SSTU-SC-ENG-SRB-A, SSTU-SC-ENG-SRB-B, SSTU-SC-ENG-SRB-C
 author = Shadowmage
 
 TechRequired = basicRocketry

--- a/GameData/SSTU/Parts/ShipCore/SRB/Upgrades-SRB.cfg
+++ b/GameData/SSTU/Parts/ShipCore/SRB/Upgrades-SRB.cfg
@@ -1,0 +1,51 @@
+PARTUPGRADE
+{
+	name = SSTU-SC-ENG-SRB-GeneralRocketry
+	partIcon = SSTU-SC-ENG-SRB-A
+	techRequired = generalRocketry
+	entryCost = 2000
+	cost = 0
+
+	title = Modular SRB Efficiency Upgrade
+	manufacturer = SSTU
+	description = A new, more explosive fuel mixture improves the burning efficiency of solid rockets.
+}
+
+PARTUPGRADE
+{
+	name = SSTU-SC-ENG-SRB-HeavyRocketry
+	partIcon = SSTU-SC-ENG-SRB-A
+	techRequired = heavyRocketry
+	entryCost = 6000
+	cost = 0
+
+	title = Modular SRB Efficiency Upgrade
+	manufacturer = SSTU
+	description = A higher chamber pressure improves the specific impulse of solid rockets.
+}
+
+PARTUPGRADE
+{
+	name = SSTU-SC-ENG-SRB-HeavierRocketry
+	partIcon = SSTU-SC-ENG-SRB-A
+	techRequired = heavierRocketry
+	entryCost = 12000
+	cost = 0
+
+	title = Modular SRB Efficiency Upgrade
+	manufacturer = SSTU
+	description = Improvements to the nozzle design increase the specific impulse of solid rockets.
+}
+
+PARTUPGRADE
+{
+	name = SSTU-SC-ENG-SRB-VeryHeavyRocketry
+	partIcon = SSTU-SC-ENG-SRB-A
+	techRequired = advHeavyRocketry
+	entryCost = 30000
+	cost = 0
+
+	title = Modular SRB Efficiency Upgrade
+	manufacturer = SSTU
+	description = Improvements to the nozzle design increase the specific impulse of solid rockets.
+}


### PR DESCRIPTION
This matches the Isp of the SRBs that of the stock SRBs that you unlock at each level, with some improvements beyond that too.  I matched the final upgrade to about what the real Shuttle SRBs get, but maybe it's a bit high, not sure.

I also made it so that the SRBs unlock together (using `identicalParts` field), since it seems unlikely that you would want to unlock one and not the others.