### PR TITLE
MHS dedicated upgrade path, follows tank sizes

### DIFF
--- a/GameData/SSTU/Parts/ShipCore/General/ModularHeatShield/SC-GEN-MHS.cfg
+++ b/GameData/SSTU/Parts/ShipCore/General/ModularHeatShield/SC-GEN-MHS.cfg
@@ -102,22 +102,22 @@ MODULE
 	{
 		UPGRADE
 		{
-			name__ = SSTU-FR-D1
+			name__ = SSTU-MHS-D1
+			maxDiameter = 1.875
+		}
+		UPGRADE
+		{
+			name__ = SSTU-MHS-D2
 			maxDiameter = 2.5
 		}
 		UPGRADE
 		{
-			name__ = SSTU-FR-D2
+			name__ = SSTU-MHS-D3
 			maxDiameter = 3.75
 		}
 		UPGRADE
 		{
-			name__ = SSTU-FR-D3
-			maxDiameter = 6.25
-		}
-		UPGRADE
-		{
-			name__ = SSTU-FR-D4
+			name__ = SSTU-MHS-D4
 			maxDiameter = 10
 		}
 	}


### PR DESCRIPTION
only 4 nodes as the stock heatshield path does not go further so we go from 2.5 to 3.75 to 10m instead of the usual 2.5/3.125/3.75/6.25/10