### PR TITLE
PPC dedicated upgrade path, follows tank sizes

### DIFF
--- a/GameData/SSTU/Parts/ShipCore/General/ProbeCore/SC-GEN-PPC.cfg
+++ b/GameData/SSTU/Parts/ShipCore/General/ProbeCore/SC-GEN-PPC.cfg
@@ -66,22 +66,32 @@ MODULE
 	{
 		UPGRADE
 		{
-			name__ = SSTU-FR-D1
+			name__ = SSTU-PPC-D1
+			maxDiameter = 1.875
+		}
+		UPGRADE
+		{
+			name__ = SSTU-PPC-D2
 			maxDiameter = 2.5
 		}
 		UPGRADE
 		{
-			name__ = SSTU-FR-D2
+			name__ = SSTU-PPC-D3
+			maxDiameter = 3.125
+		}
+		UPGRADE
+		{
+			name__ = SSTU-PPC-D4
 			maxDiameter = 3.75
 		}
 		UPGRADE
 		{
-			name__ = SSTU-FR-D3
+			name__ = SSTU-PPC-D5
 			maxDiameter = 6.25
 		}
 		UPGRADE
 		{
-			name__ = SSTU-FR-D4
+			name__ = SSTU-PPC-D6
 			maxDiameter = 10
 		}
 	}	


### PR DESCRIPTION
dedicated path that follows stock probe cores in the techtree