### PR TITLE
Expose deployment state to other mods

### DIFF
--- a/Plugin/SSTUTools/SSTUTools/Module/SSTUModularParachute.cs
+++ b/Plugin/SSTUTools/SSTUTools/Module/SSTUModularParachute.cs
@@ -806,12 +806,12 @@ namespace SSTUTools
             }
         }
 
-        private bool isMainChuteDeployed()
+        public bool isMainChuteDeployed()
         {
             return chuteState == ChuteState.MAIN_DEPLOYING_FULL || chuteState == ChuteState.MAIN_DEPLOYING_SEMI || chuteState == ChuteState.MAIN_FULL_DEPLOYED || chuteState == ChuteState.MAIN_SEMI_DEPLOYED;
         }
 
-        private bool isDrogueChuteDeployed()
+        public bool isDrogueChuteDeployed()
         {
             return chuteState == ChuteState.DROGUE_DEPLOYING_FULL || chuteState == ChuteState.DROGUE_DEPLOYING_SEMI || chuteState == ChuteState.DROGUE_FULL_DEPLOYED || chuteState == ChuteState.DROGUE_SEMI_DEPLOYED;
         }


### PR DESCRIPTION
This lets other mods (like [SafeChute](https://forum.kerbalspaceprogram.com/index.php?/topic/90954-130-safechute-v217-continued/)) tell whether the parachutes have been deployed.

If there's a better way (besides parsing chutePersistence, which is already public), please let me know