### PR TITLE
Fix typos and change RD-181 description from RD-170

### DIFF
--- a/GameData/SSTU/Parts/Engines/SC-ENG-RD-171.cfg
+++ b/GameData/SSTU/Parts/Engines/SC-ENG-RD-171.cfg
@@ -11,7 +11,7 @@ category = Engine
 subcategory = 0
 title = SSTU - SC-ENG - RD-171
 manufacturer = SSTU
-description = SSTU - ShipCore: Engines - RD-171.  This is what happens when you give your engineers an vat of industrial strength superglue.  Comprised of four combustion chambers (the same used on the RD-191) and a single turbopump assembly this engine provides ample thrust for large lower stage lifter designs.
+description = SSTU - ShipCore: Engines - RD-171.  This is what happens when you give your engineers an vat of industrial strength superglue.  Comprised of four combustion chambers (the same used on the RD-181) and a single turbopump assembly this engine provides ample thrust for large lower stage lifter designs.
 tags = ?lfo, kerolox, main, ascent, atmo
 
 MODEL

--- a/GameData/SSTU/Parts/Engines/SC-ENG-RD-180.cfg
+++ b/GameData/SSTU/Parts/Engines/SC-ENG-RD-180.cfg
@@ -11,7 +11,7 @@ category = Engine
 subcategory = 0
 title = SSTU - SC-ENG - RD-180
 manufacturer = SSTU
-description = SSTU - ShipCore: Engines - RD-180.  Using the same combustion chamber as the RD-191, this engine combines two combustion chambers with an upgraded turbopump assembly to provide quite nearly twice the thrust of its smaller sibling.
+description = SSTU - ShipCore: Engines - RD-180.  Using the same combustion chamber as the RD-181, this engine combines two combustion chambers with an upgraded turbopump assembly to provide quite nearly twice the thrust of its smaller sibling.
 tags = ?lfo, kerolox, main, ascent, atmo
 
 MODEL

--- a/GameData/SSTU/Parts/Engines/SC-ENG-RD-181.cfg
+++ b/GameData/SSTU/Parts/Engines/SC-ENG-RD-181.cfg
@@ -11,7 +11,7 @@ category = Engine
 subcategory = 0
 title = SSTU - SC-ENG - RD-181
 manufacturer = SSTU
-description = SSTU - ShipCore: Engines - RD-181.  This is what happens when you give your engineers an vat of industrial strength superglue.  Comprised of four combustion chambers (the same used on the RD-191) and a single turbopump assembly this engine provides ample thrust for large lower stage lifter designs.
+description = SSTU - ShipCore: Engines - RD-181.  This is what happens when you tempt your engineers an vat of industrial strength superglue.  Designed as the base of a modular system of high performance engines, the RD-181 comprises of one combustion chamber and one turbopump. Larger engines in this series cluster multiple combustion chambers with larger turbopumps.
 tags = ?lfo, kerolox, main, ascent, atmo
 
 MODEL

--- a/GameData/SSTU/Parts/Engines/SC-ENG-RL10B-2.cfg
+++ b/GameData/SSTU/Parts/Engines/SC-ENG-RL10B-2.cfg
@@ -11,7 +11,7 @@ category = Engine
 subcategory = 0
 title = SSTU - SC-ENG - RL10B-2
 manufacturer = SSTU
-description = Leaning on the lessons learned from the painful redesign of the RL10A-4, the senior engineers this time decided to go with the nozzle-elevator from the start of the design.  While it re-uses many fuel pumping components from the RL10A-3 and RL10A-4, the RL10B-2 has a completely redesigned main nozzle, and a much longer (and larger) nozzle extension.  These changes allow for a fairly substantial increase in vacuum thrust as well as slightly increasing vacuum efficiency.  However, they come at the cost of a lower thrust-to-weight ratio, and an overall larger an heavier engine.
+description = Leaning on the lessons learned from the painful redesign of the RL10A-4, the senior engineers this time decided to go with the nozzle-elevator from the start of the design.  While it re-uses many fuel pumping components from the RL10A-3 and RL10A-4, the RL10B-2 has a completely redesigned main nozzle, and a much longer (and larger) nozzle extension.  These changes allow for a fairly substantial increase in vacuum thrust as well as slightly increasing vacuum efficiency.  However, they come at the cost of a lower thrust-to-weight ratio, and an overall larger and heavier engine.
 tags = lh2, hydrolox, vacuum, sustainer, second, efficient
 
 MODEL


### PR DESCRIPTION
Sorry if I'm overstepping anything, feel free decline this.
Fixed RL10B-2 description (typo)
Changed RD-170 and RD-180 to reference RD-181 as the base engine in description
Wrote a new RD-181 description up as it was just using RD-170's one. I tried to keep the same tone as the previous one.

Ignore the final commit, that was a pull request on my fork as I made my changes in master instead of dev.

In reality the RD-170 came before the RD-180 and then the RD-181 (which is really a RD-191 from the stats in the config). Would you be open to it if I wrote up some new descriptions to fit that? I've got a humorous idea for them.
