### PR TITLE
RealPlume v11.2.0 updates

### DIFF
--- a/GameData/SSTU/ModIntegration/RealPlume/RealPlumes-Engines.cfg
+++ b/GameData/SSTU/ModIntegration/RealPlume/RealPlumes-Engines.cfg
@@ -61,10 +61,34 @@
         energy = 1
         speed = 1
     }
-	@MODULE[ModuleEngines*]
-	{
-        %powerEffectName = Kerolox-Lower-F1
-	}
+    PLUME
+    {
+        name = Kerolox-Exhaust
+        transformName = F1B-ExhaustTransform
+        localRotation = 0,0,0
+        localPosition = 0,0,1.1
+        fixedScale = 3
+        energy = 1
+        speed = 1
+    }
+}
+@PART[SSTU-SC-ENG-F1B]:NEEDS[RealPlume&!RealismOverhaul]:FOR[zzPostRealPlumeSSTU]
+{
+    @EFFECTS
+    {
+        @Kerolox-Lower-F1
+        {
+            |_ = CombinedPlume
+        }
+        @Kerolox-Exhaust
+        {
+            |_ = CombinedPlume
+        }
+    }
+    @MODULE[ModuleEngines*]
+    {
+        %powerEffectName = CombinedPlume
+    }
 }
 @PART[SSTU-SC-ENG-J-2]:NEEDS[RealPlume&!RealismOverhaul]:BEFORE[RealPlume]
 {
@@ -114,19 +138,32 @@
     }
     PLUME
     {
-        name = Kerolox-Upper
+        name = Kerolox-Vernier
         transformName = RD-107A-VernierFXTransform
         localRotation = 0,0,0
         localPosition = 0,0,0.25
-        fixedScale = 0.1
+        fixedScale = 2
         energy = 0.4
         speed = 1
     }
-	@MODULE[ModuleEngines*]
-	{
-        %powerEffectName = Kerolox-Lower
-		%runningEffectName = Kerolox-Upper
-	}
+}
+@PART[SSTU-SC-ENG-RD-107A]:NEEDS[RealPlume&!RealismOverhaul]:FOR[zzPostRealPlumeSSTU]
+{
+    @EFFECTS
+    {
+        @Kerolox-Lower
+        {
+            |_ = CombinedPlume
+        }
+        @Kerolox-Vernier
+        {
+            |_ = CombinedPlume
+        }
+    }
+    @MODULE[ModuleEngines*]
+    {
+        %powerEffectName = CombinedPlume
+    }
 }
 @PART[SSTU-SC-ENG-RD-107X]:NEEDS[RealPlume&!RealismOverhaul]:BEFORE[RealPlume]
 {
@@ -159,19 +196,32 @@
     }
     PLUME
     {
-        name = Kerolox-Upper
+        name = Kerolox-Vernier
         transformName = RD-108A-VernierFXTransform
         localRotation = 0,0,0
         localPosition = 0,0,0.25
-        fixedScale = 0.1
+        fixedScale = 2
         energy = 0.4
         speed = 1
     }
-	@MODULE[ModuleEngines*]
-	{
-        %powerEffectName = Kerolox-Lower
-		%runningEffectName = Kerolox-Upper
-	}
+}
+@PART[SSTU-SC-ENG-RD-108A]:NEEDS[RealPlume&!RealismOverhaul]:FOR[zzPostRealPlumeSSTU]
+{
+    @EFFECTS
+    {
+        @Kerolox-Lower
+        {
+            |_ = CombinedPlume
+        }
+        @Kerolox-Vernier
+        {
+            |_ = CombinedPlume
+        }
+    }
+    @MODULE[ModuleEngines*]
+    {
+        %powerEffectName = CombinedPlume
+    }
 }
 @PART[SSTU-SC-ENG-RD-0110]:NEEDS[RealPlume&!RealismOverhaul]:BEFORE[RealPlume]
 {
@@ -187,19 +237,32 @@
     }
     PLUME
     {
-        name = Kerolox-Lower
+        name = Kerolox-Exhaust
         transformName = RD-0110-VernierFXTransform
         localRotation = 0,0,0
         localPosition = 0,0,0.05
-        fixedScale = 0.075
-        energy = 0.2
+        fixedScale = 1.5
+        energy = 1
         speed = 1
     }
-	@MODULE[ModuleEngines*]
-	{
-        %powerEffectName = Kerolox-Upper
-        %runningEffectName = Kerolox-Lower
-	}
+}
+@PART[SSTU-SC-ENG-RD-0110]:NEEDS[RealPlume&!RealismOverhaul]:FOR[zzPostRealPlumeSSTU]
+{
+    @EFFECTS
+    {
+        @Kerolox-Upper
+        {
+            |_ = CombinedPlume
+        }
+        @Kerolox-Exhaust
+        {
+            |_ = CombinedPlume
+        }
+    }
+    @MODULE[ModuleEngines*]
+    {
+        %powerEffectName = CombinedPlume
+    }
 }
 @PART[SSTU-SC-ENG-RD-180]:NEEDS[RealPlume&!RealismOverhaul]:BEFORE[RealPlume]
 {
@@ -361,11 +424,24 @@
         energy = 1
         speed = 0.5
     }
-	@MODULE[ModuleEngines*],0
-	{
-        %powerEffectName = Hydrolox-Lower
-        %runningEffectName = Hydrolox-Upper
-	}
+}
+@PART[SSTU-SC-ENG-RS-68]:NEEDS[RealPlume&!RealismOverhaul]:FOR[zzPostRealPlumeSSTU]
+{
+    @EFFECTS
+    {
+        @Hydrolox-Lower
+        {
+            |_ = CombinedPlume
+        }
+        @Hydrolox-Upper
+        {
+            |_ = CombinedPlume
+        }
+    }
+    @MODULE[ModuleEngines*]
+    {
+        %powerEffectName = CombinedPlume
+    }
 }
 @PART[SSTU-SC-ENG-H1]:NEEDS[RealPlume&!RealismOverhaul]:BEFORE[RealPlume]
 {
@@ -397,10 +473,34 @@
         energy = 0.5
         speed = 1
     }
-	@MODULE[ModuleEngines*]
-	{
-        %powerEffectName = Kerolox-Lower
-	}
+    PLUME
+    {
+        name = Kerolox-Exhaust
+        transformName = Merlin-1A-RollFXTransform
+        localRotation = 0,0,0
+        localPosition = 0,0,0.03
+        fixedScale = 0.75
+        energy = 1
+        speed = 1
+    }
+}
+@PART[SSTU-SC-ENG-Merlin-1A]:NEEDS[RealPlume&!RealismOverhaul]:FOR[zzPostRealPlumeSSTU]
+{
+    @EFFECTS
+    {
+        @Kerolox-Lower
+        {
+            |_ = CombinedPlume
+        }
+        @Kerolox-Exhaust
+        {
+            |_ = CombinedPlume
+        }
+    }
+    @MODULE[ModuleEngines*]
+    {
+        %powerEffectName = CombinedPlume
+    }
 }
 @PART[SSTU-SC-ENG-Merlin-1B]:NEEDS[RealPlume&!RealismOverhaul]:BEFORE[RealPlume]
 {
@@ -414,10 +514,34 @@
         energy = 0.5
         speed = 1
     }
-	@MODULE[ModuleEngines*]
-	{
-        %powerEffectName = Kerolox-Lower
-	}
+    PLUME
+    {
+        name = Kerolox-Exhaust
+        transformName = Merlin-1B-RollFXTransform
+        localRotation = 0,0,0
+        localPosition = 0,0,0.03
+        fixedScale = 0.75
+        energy = 1
+        speed = 1
+    }
+}
+@PART[SSTU-SC-ENG-Merlin-1B]:NEEDS[RealPlume&!RealismOverhaul]:FOR[zzPostRealPlumeSSTU]
+{
+    @EFFECTS
+    {
+        @Kerolox-Lower
+        {
+            |_ = CombinedPlume
+        }
+        @Kerolox-Exhaust
+        {
+            |_ = CombinedPlume
+        }
+    }
+    @MODULE[ModuleEngines*]
+    {
+        %powerEffectName = CombinedPlume
+    }
 }
 @PART[SSTU-SC-ENG-Merlin-1BV]:NEEDS[RealPlume&!RealismOverhaul]:BEFORE[RealPlume]
 {
@@ -431,10 +555,34 @@
         energy = 0.5
         speed = 1
     }
-	@MODULE[ModuleEngines*]
-	{
-        %powerEffectName = Kerolox-Upper
-	}
+    PLUME
+    {
+        name = Kerolox-Exhaust
+        transformName = Merlin-1BV-RollFXTransform
+        localRotation = 0,0,0
+        localPosition = 0,0,0.03
+        fixedScale = 0.75
+        energy = 1
+        speed = 1
+    }
+}
+@PART[SSTU-SC-ENG-Merlin-1BV]:NEEDS[RealPlume&!RealismOverhaul]:FOR[zzPostRealPlumeSSTU]
+{
+    @EFFECTS
+    {
+        @Kerolox-Upper
+        {
+            |_ = CombinedPlume
+        }
+        @Kerolox-Exhaust
+        {
+            |_ = CombinedPlume
+        }
+    }
+    @MODULE[ModuleEngines*]
+    {
+        %powerEffectName = CombinedPlume
+    }
 }
 @PART[SSTU-SC-ENG-Merlin-1C]:NEEDS[RealPlume&!RealismOverhaul]:BEFORE[RealPlume]
 {
@@ -448,10 +596,34 @@
         energy = 0.5
         speed = 1
     }
-	@MODULE[ModuleEngines*]
-	{
-        %powerEffectName = Kerolox-Lower
-	}
+    PLUME
+    {
+        name = Kerolox-Exhaust
+        transformName = Merlin-1C-ThrustTransform
+        localRotation = 0,6.75,0
+        localPosition = 0.58,0,0.16
+        fixedScale = 0.75
+        energy = 1
+        speed = 1
+    }
+}
+@PART[SSTU-SC-ENG-Merlin-1C]:NEEDS[RealPlume&!RealismOverhaul]:FOR[zzPostRealPlumeSSTU]
+{
+    @EFFECTS
+    {
+        @Kerolox-Lower
+        {
+            |_ = CombinedPlume
+        }
+        @Kerolox-Exhaust
+        {
+            |_ = CombinedPlume
+        }
+    }
+    @MODULE[ModuleEngines*]
+    {
+        %powerEffectName = CombinedPlume
+    }
 }
 @PART[SSTU-SC-ENG-Merlin-1CV]:NEEDS[RealPlume&!RealismOverhaul]:BEFORE[RealPlume]
 {
@@ -465,10 +637,34 @@
         energy = 0.5
         speed = 1
     }
-	@MODULE[ModuleEngines*]
-	{
-        %powerEffectName = Kerolox-Upper
-	}
+    PLUME
+    {
+        name = Kerolox-Exhaust
+        transformName = Merlin-1CV-ThrustTransform
+        localRotation = 0,16.75,0
+        localPosition = 0.80,0,0.51
+        fixedScale = 0.75
+        energy = 1
+        speed = 1
+    }
+}
+@PART[SSTU-SC-ENG-Merlin-1CV]:NEEDS[RealPlume&!RealismOverhaul]:FOR[zzPostRealPlumeSSTU]
+{
+    @EFFECTS
+    {
+        @Kerolox-Upper
+        {
+            |_ = CombinedPlume
+        }
+        @Kerolox-Exhaust
+        {
+            |_ = CombinedPlume
+        }
+    }
+    @MODULE[ModuleEngines*]
+    {
+        %powerEffectName = CombinedPlume
+    }
 }
 @PART[SSTU-SC-ENG-Merlin-1D]:NEEDS[RealPlume&!RealismOverhaul]:BEFORE[RealPlume]
 {
@@ -482,10 +678,34 @@
         energy = 0.5
         speed = 1
     }
-	@MODULE[ModuleEngines*]
-	{
-        %powerEffectName = Kerolox-Lower
-	}
+    PLUME
+    {
+        name = Kerolox-Exhaust
+        transformName = Merlin-1D-ThrustTransform
+        localRotation = 0,0,0
+        localPosition = 0.48,0,-0.05
+        fixedScale = 1
+        energy = 1
+        speed = 1
+    }
+}
+@PART[SSTU-SC-ENG-Merlin-1D]:NEEDS[RealPlume&!RealismOverhaul]:FOR[zzPostRealPlumeSSTU]
+{
+    @EFFECTS
+    {
+        @Kerolox-Lower
+        {
+            |_ = CombinedPlume
+        }
+        @Kerolox-Exhaust
+        {
+            |_ = CombinedPlume
+        }
+    }
+    @MODULE[ModuleEngines*]
+    {
+        %powerEffectName = CombinedPlume
+    }
 }
 @PART[SSTU-SC-ENG-Merlin-1DV]:NEEDS[RealPlume&!RealismOverhaul]:BEFORE[RealPlume]
 {
@@ -519,19 +739,32 @@
     }
     PLUME
     {
-        name = Hypergolic-Lower
+        name = Hypergolic-Vernier
         transformName = LR-81-8048-ExhaustTransform
         localRotation = 0,0,0
-        localPosition = 0,0,0.12
-        fixedScale = 0.2
+        localPosition = 0,0,1
+        fixedScale = 0.5
         energy = 1
         speed = 1
     }
-	@MODULE[ModuleEngines*]
-	{
-        %powerEffectName = Hypergolic-Upper
-		%runningEffectName = Hypergolic-Lower
-	}
+}
+@PART[SSTU-SC-ENG-LR81-8048]:NEEDS[RealPlume&!RealismOverhaul]:FOR[zzPostRealPlumeSSTU]
+{
+    @EFFECTS
+    {
+        @Hypergolic-Upper
+        {
+            |_ = CombinedPlume
+        }
+        @Hypergolic-Vernier
+        {
+            |_ = CombinedPlume
+        }
+    }
+    @MODULE[ModuleEngines*]
+    {
+        %powerEffectName = CombinedPlume
+    }
 }
 @PART[SSTU-SC-ENG-LR81-8096]:NEEDS[RealPlume&!RealismOverhaul]:BEFORE[RealPlume]
 {
@@ -547,19 +780,32 @@
     }
     PLUME
     {
-        name = Hypergolic-Lower
+        name = Hypergolic-Vernier
         transformName = LR-81-8096-ExhaustTransform
         localRotation = 0,0,0
-        localPosition = 0,0,0.4
-        fixedScale = 0.2
+        localPosition = 0,0,1
+        fixedScale = 0.5
         energy = 1
         speed = 1
     }
-	@MODULE[ModuleEngines*]
-	{
-        %powerEffectName = Hypergolic-Upper
-		%runningEffectName = Hypergolic-Lower
-	}
+}
+@PART[SSTU-SC-ENG-LR81-8096]:NEEDS[RealPlume&!RealismOverhaul]:FOR[zzPostRealPlumeSSTU]
+{
+    @EFFECTS
+    {
+        @Hypergolic-Upper
+        {
+            |_ = CombinedPlume
+        }
+        @Hypergolic-Vernier
+        {
+            |_ = CombinedPlume
+        }
+    }
+    @MODULE[ModuleEngines*]
+    {
+        %powerEffectName = CombinedPlume
+    }
 }
 @PART[SSTU-SC-ENG-SuperDraco]:NEEDS[RealPlume&!RealismOverhaul]:BEFORE[RealPlume]
 {
@@ -631,25 +877,6 @@
         %powerEffectName = Hypergolic-Apollo-SM
 	}
 }
-@PART[SSTU-SC-ENG-LR81]:NEEDS[RealPlume&!RealismOverhaul]:BEFORE[RealPlume]
-{
-    PLUME
-    {
-        name = Hypergolic-Upper
-        transformName = F1B-ThrustTransform
-        localRotation = 0,0,0
-        localPosition = 0,0,3
-        fixedScale = 0.8
-        energy = 1
-        speed = 1
-    }
-	@MODULE[ModuleEngines*]
-	{
-        %powerEffectName = Hypergolic-Upper
-	}
-}
-
-
 @PART[SSTU-SC-ENG-NRV]:NEEDS[RealPlume&!RealismOverhaul]:BEFORE[RealPlume]
 {
     PLUME


### PR DESCRIPTION
* User Kerolox-Vernier plume on RD-107/8
* Add turbine exhaust plumes to LR-81 engines using Hypergolic-Vernier plume
* Use new Kerolox-Exhaust plume on F-1B, RD-0110, Merlins
* Combine plumes after RealPlume runs rathe than using powerEffectName and runningEffectName