### PR TITLE
Update SSTU-EL-Patch.cfg

### DIFF
--- a/GameData/SSTU/ModIntegration/EPL/SSTU-EL-Patch.cfg
+++ b/GameData/SSTU/ModIntegration/EPL/SSTU-EL-Patch.cfg
@@ -2,7 +2,7 @@
 {
     MODULE
     {
-        name = ExWorkshop
+        name = ELWorkshop
         ProductivityFactor = 1
     }
 }
@@ -10,7 +10,7 @@
 {
     MODULE
     {
-        name = ExWorkshop
+        name = ELWorkshop
         ProductivityFactor = 1.5
     }
 }
@@ -18,7 +18,7 @@
 {
     MODULE
     {
-        name = ExWorkshop
+        name = ELWorkshop
         ProductivityFactor = 2
     }
 }
@@ -26,7 +26,7 @@
 {
     MODULE
     {
-        name = ExWorkshop
+        name = ELWorkshop
         ProductivityFactor = 2.5
     }
 }


### PR DESCRIPTION
As per #776.

- This corrects the spelling error in the config.
- This does not _yet_ address a request for rebalancing the `ProductivityFactor` to better match Nertea's `StationPartsExpansionRedux`, i.e. increasing the EL productivity for the larger station modules.