### PR TITLE
Fixed previous CLS station part MM patch

### DIFF
--- a/GameData/SSTU/ModIntegration/CLS/CLS.cfg
+++ b/GameData/SSTU/ModIntegration/CLS/CLS.cfg
@@ -47,7 +47,7 @@
 	}
 }
 
-@PART[SSTU-ST-*]:HAS[!MODULE[ModuleConnectedLivingSpace]]:FOR[SSTU]:NEEDS[ConnectedLivingSpace]
+@PART[SSTU-ST-HAB|SSTU-ST-DOC|SSTU-ST-COS]:HAS[!MODULE[ModuleConnectedLivingSpace]]:FOR[SSTU]:NEEDS[ConnectedLivingSpace]
 {
 	MODULE
 	{

--- a/GameData/SSTU/ModIntegration/CLS/CLS.cfg
+++ b/GameData/SSTU/ModIntegration/CLS/CLS.cfg
@@ -47,3 +47,11 @@
 	}
 }
 
+@PART[SSTU-ST-*]:HAS[!MODULE[ModuleConnectedLivingSpace]]:FOR[SSTU]:NEEDS[ConnectedLivingSpace]
+{
+	MODULE
+	{
+		name = ModuleConnectedLivingSpace
+		passable = true
+	}
+}

--- a/GameData/SSTU/ModIntegration/EPL/SSTU-EL-Patch.cfg
+++ b/GameData/SSTU/ModIntegration/EPL/SSTU-EL-Patch.cfg
@@ -2,7 +2,7 @@
 {
     MODULE
     {
-        name = ExWorkshop
+        name = ELWorkshop
         ProductivityFactor = 1
     }
 }
@@ -10,7 +10,7 @@
 {
     MODULE
     {
-        name = ExWorkshop
+        name = ELWorkshop
         ProductivityFactor = 1.5
     }
 }
@@ -18,7 +18,7 @@
 {
     MODULE
     {
-        name = ExWorkshop
+        name = ELWorkshop
         ProductivityFactor = 2
     }
 }
@@ -26,7 +26,7 @@
 {
     MODULE
     {
-        name = ExWorkshop
+        name = ELWorkshop
         ProductivityFactor = 2.5
     }
 }


### PR DESCRIPTION
Corrected bug in #777. Made the previous patch more specific in what parts were altered.

Instead of `SSTU-ST*`, match `SSTU-ST-HAB|SSTU-ST-DOC|SSTU-ST-COS`.