### PR TITLE
Update CLS.cfg

### DIFF
--- a/GameData/SSTU/ModIntegration/CLS/CLS.cfg
+++ b/GameData/SSTU/ModIntegration/CLS/CLS.cfg
@@ -47,7 +47,7 @@
 	}
 }
 
-@PART[SSTU-ST-HAB|SSTU-ST-DOC|SSTU-ST-COS]:HAS[!MODULE[ModuleConnectedLivingSpace]]:FOR[SSTU]:NEEDS[ConnectedLivingSpace]
+@PART[SSTU-ST-HAB*|SSTU-ST-DOC*|SSTU-ST-COS*]:HAS[!MODULE[ModuleConnectedLivingSpace]]:FOR[SSTU]:NEEDS[ConnectedLivingSpace]
 {
 	MODULE
 	{


### PR DESCRIPTION
Made a correction to the existing CLS MM patch for `SSTU-ST-HAB`, `SSTU-ST-DOC`, and `SSTU-ST-COS` families of parts.
- added wildcard