### PR TITLE
Textureless Fairing Fix

### DIFF
--- a/GameData/SSTU/Parts/General/Fairings/SC-GEN-FR-N.cfg
+++ b/GameData/SSTU/Parts/General/Fairings/SC-GEN-FR-N.cfg
@@ -57,7 +57,7 @@ MODULE
 	
 	nSides = 26
 	nArcs = 2	
-	TextureURL = SSTU/Assets/SC-GEN-Fairing-DIFF
+	TextureURL = SSTU/Assets/SC-GEN-FR-DIFF
 	
 	panelGrouping = 3
 	pivot = 0,0,0

--- a/GameData/SSTU/Parts/General/Fairings/SC-GEN-FR-W.cfg
+++ b/GameData/SSTU/Parts/General/Fairings/SC-GEN-FR-W.cfg
@@ -57,7 +57,7 @@ MODULE
 	
 	nSides = 26
 	nArcs = 2
-	TextureURL = SSTU/Assets/SC-GEN-Fairing-DIFF
+	TextureURL = SSTU/Assets/SC-GEN-FR-DIFF
 	
 	panelGrouping = 3
 	pivot = 0,0,0


### PR DESCRIPTION
Small change to the two main fairing parts, SC-GEN-FR-N.cfg and SC-GEN-FR-W.cfg, which currently appear invisible without a texture on the panels when you try to build the fairing.

Changed "TextureURL = SSTU/Assets/SC-GEN-Fairing-DIFF" in both to "TextureURL = SSTU/Assets/SC-GEN-FR-DIFF"

Used a ModuleManager patch to test the change first, but the change should be the same.