### PR TITLE
Fix MHS not visible in the tech tree

### DIFF
--- a/GameData/SSTU/Parts/Upgrades/UpgradeParts-MHS.cfg
+++ b/GameData/SSTU/Parts/Upgrades/UpgradeParts-MHS.cfg
@@ -3,7 +3,7 @@
 PARTUPGRADE
 {
 	name = SSTU-MHS-D1
-	partIcon = SSTU-SC-GEN-MHS
+	partIcon = SSTU-GEN-MHS
 	techRequired = flightControl
 	entryCost = 10000
 	title = Modular Heat Shield Diameter Increase (1.875m)
@@ -12,7 +12,7 @@ PARTUPGRADE
 PARTUPGRADE
 {
 	name = SSTU-MHS-D2
-	partIcon = SSTU-SC-GEN-MHS
+	partIcon = SSTU-GEN-MHS
 	techRequired = landing
 	entryCost = 20000
 	title = Modular Heat Shield Max Diameter Increase (2.5m)
@@ -21,7 +21,7 @@ PARTUPGRADE
 PARTUPGRADE
 {
 	name = SSTU-MHS-D3
-	partIcon = SSTU-SC-GEN-MHS
+	partIcon = SSTU-GEN-MHS
 	techRequired = advLanding
 	entryCost = 30000
 	title = Modular Heat Shield Max Diameter Increase (3.75m)
@@ -30,7 +30,7 @@ PARTUPGRADE
 PARTUPGRADE
 {
 	name = SSTU-MHS-D4
-	partIcon = SSTU-SC-GEN-MHS
+	partIcon = SSTU-GEN-MHS
 	techRequired = heavyLanding
 	entryCost = 40000
 	title = Modular Heat Shield Max Diameter Increase (10m)


### PR DESCRIPTION
#705 Fix icon names for MHS upgrades

This is probably related to #705.

Anyway, the problem is that Modular Heat Shield upgrades are not visible in the tech tree. The root cause is that icon names were specified incorrectly in the MHS upgrade config file so KSP kept throwing a NRE trying to load the icon.