### PR TITLE
ReStock Compatibility

### DIFF
--- a/GameData/SSTU/ModIntegration/ReStock/SSTU.restockwhitelist
+++ b/GameData/SSTU/ModIntegration/ReStock/SSTU.restockwhitelist
@@ -1,0 +1,6 @@
+Squad/Parts/Utility/ServiceBay/
+Squad/Parts/Resources/MiniDrill/
+Squad/Parts/Utility/commsAntennaDTS-M1/
+Squad/Parts/FuelTank/RCSTankRadial/
+Squad/Parts/FuelTank/RCStankRadialLong/
+Squad/Parts/FuelTank/xenonTankRadial/


### PR DESCRIPTION
 I'm using SSTU alongside ReStock and I've found some issue : ReStock blacklist some model/texture to save memory, unfortunately some of them are used by SSTU.

To prevent this I've made a whitelist patch for SSTU.