### PR TITLE
Update SSTU version to 1.12

### DIFF
--- a/GameData/SSTU/MiniAVC/SSTULabs.version
+++ b/GameData/SSTU/MiniAVC/SSTULabs.version
@@ -25,7 +25,7 @@
 	"KSP_VERSION_MAX":
 	{
 		"MAJOR":1,
-		"MINOR":8,
-		"PATCH":9
+		"MINOR":12,
+		"PATCH":99
 	}
 }


### PR DESCRIPTION
Looks like there's a couple wrinkles (anecdotal reports of SRB issues, which I did not experience; and perhaps an issue with PBR shading and emissives, which I noticed on the Apollo SM's SPS) but nothing that should prevent people enjoying the mod in 1.12.

I am not PRing version updates to the other mods in this repo, since they are updated elsewhere.