### PR TITLE
Update USI-LS patch

### DIFF
--- a/GameData/SSTU/ModIntegration/USI/USI-LS/USI-LS-LC.cfg
+++ b/GameData/SSTU/ModIntegration/USI/USI-LS/USI-LS-LC.cfg
@@ -2,8 +2,36 @@
 @PART[SSTU-LC2-POD]:FOR[SSTU]:NEEDS[USILifeSupport] // 2-person pod
 {
 	MODULE
+	MODULE
 	{
-		name = ModuleLifeSupport
+		name = USI_SwapController
+	}
+	MODULE
+	{
+		name = USI_SwappableBay
+		bayName = Bay 1
+		moduleIndex = 0
+	}
+	MODULE
+	{
+		name = USI_Converter
+		UseSpecialistBonus = false
+	}
+	MODULE
+	{
+		name = USILS_LifeSupportRecyclerSwapOption
+		ConverterName = Life Support
+		StartActionName = Start Life Support
+		StopActionName = Stop Life Support
+
+		CrewCapacity = 2
+		RecyclePercent = 0.25
+
+		INPUT_RESOURCE
+		{
+			ResourceName = ElectricCharge
+			Ratio = 1
+		}
 	}
 	@MODULE[SSTUVolumeContainer]
 	{
@@ -25,7 +53,34 @@
 {
 	MODULE
 	{
-		name = ModuleLifeSupport
+		name = USI_SwapController
+	}
+	MODULE
+	{
+		name = USI_SwappableBay
+		bayName = Bay 1
+		moduleIndex = 0
+	}
+	MODULE
+	{
+		name = USI_Converter
+		UseSpecialistBonus = false
+	}
+	MODULE
+	{
+		name = USILS_LifeSupportRecyclerSwapOption
+		CrewCapacity = 3
+		RecyclePercent = .25
+		ConverterName = Life Support
+		StartActionName = Start Life Support
+		StopActionName = Stop Life Support
+		ToggleActionName = Toggle Life Support
+
+		INPUT_RESOURCE
+		{
+			ResourceName = ElectricCharge
+			Ratio = 1
+		}
 	}
 	@MODULE[SSTUVolumeContainer]
 	{
@@ -47,7 +102,34 @@
 {
 	MODULE
 	{
-		name = ModuleLifeSupport
+		name = USI_SwapController
+	}
+	MODULE
+	{
+		name = USI_SwappableBay
+		bayName = Bay 1
+		moduleIndex = 0
+	}
+	MODULE
+	{
+		name = USI_Converter
+		UseSpecialistBonus = false
+	}
+	MODULE
+	{
+		name = USILS_LifeSupportRecyclerSwapOption
+		CrewCapacity = 6
+		RecyclePercent = .5
+		ConverterName = Life Support
+		StartActionName = Start Life Support
+		StopActionName = Stop Life Support
+		ToggleActionName = Toggle Life Support
+
+		INPUT_RESOURCE
+		{
+			ResourceName = ElectricCharge
+			Ratio = 1
+		}
 	}
 	@MODULE[SSTUVolumeContainer]
 	{

--- a/GameData/SSTU/ModIntegration/USI/USI-LS/USI-LS-SC.cfg
+++ b/GameData/SSTU/ModIntegration/USI/USI-LS/USI-LS-SC.cfg
@@ -6,7 +6,34 @@
 	@mass -= 0.065
 	MODULE
 	{
-		name = ModuleLifeSupport
+		name = USI_SwapController
+	}
+	MODULE
+	{
+		name = USI_SwappableBay
+		bayName = Bay 1
+		moduleIndex = 0
+	}
+	MODULE
+	{
+		name = USI_Converter
+		UseSpecialistBonus = false
+	}
+	MODULE
+	{
+		name = USILS_LifeSupportRecyclerSwapOption
+		ConverterName = Life Support
+		StartActionName = Start Life Support
+		StopActionName = Stop Life Support
+
+		CrewCapacity = 2
+		RecyclePercent = 0.25
+
+		INPUT_RESOURCE
+		{
+			ResourceName = ElectricCharge
+			Ratio = 1
+		}
 	}
 	RESOURCE
 	{
@@ -27,7 +54,34 @@
 	@mass -= 0.065
 	MODULE
 	{
-		name = ModuleLifeSupport
+		name = USI_SwapController
+	}
+	MODULE
+	{
+		name = USI_SwappableBay
+		bayName = Bay 1
+		moduleIndex = 0
+	}
+	MODULE
+	{
+		name = USI_Converter
+		UseSpecialistBonus = false
+	}
+	MODULE
+	{
+		name = USILS_LifeSupportRecyclerSwapOption
+		ConverterName = Life Support
+		StartActionName = Start Life Support
+		StopActionName = Stop Life Support
+
+		CrewCapacity = 2
+		RecyclePercent = 0.25
+
+		INPUT_RESOURCE
+		{
+			ResourceName = ElectricCharge
+			Ratio = 1
+		}
 	}
 	RESOURCE
 	{
@@ -53,7 +107,33 @@
 	@mass -= 0.146
 	MODULE
 	{
-		name = ModuleLifeSupport
+		name = USI_SwapController
+	}
+	MODULE
+	{
+		name = USI_SwappableBay
+		bayName = Bay 1
+		moduleIndex = 0
+	}
+	MODULE
+	{
+		name = USI_Converter
+		UseSpecialistBonus = false
+	}
+	MODULE
+	{
+		name = USILS_LifeSupportRecyclerSwapOption
+		ConverterName = Life Support
+		StartActionName = Start Life Support
+		StopActionName = Stop Life Support
+		CrewCapacity = 3
+		RecyclePercent = 0.25
+
+		INPUT_RESOURCE
+		{
+			ResourceName = ElectricCharge
+			Ratio = 1
+		}
 	}
 	RESOURCE
 	{
@@ -74,7 +154,33 @@
 	@mass -= 0.097
 	MODULE
 	{
-		name = ModuleLifeSupport
+		name = USI_SwapController
+	}
+	MODULE
+	{
+		name = USI_SwappableBay
+		bayName = Bay 1
+		moduleIndex = 0
+	}
+	MODULE
+	{
+		name = USI_Converter
+		UseSpecialistBonus = false
+	}
+	MODULE
+	{
+		name = USILS_LifeSupportRecyclerSwapOption
+		ConverterName = Life Support
+		StartActionName = Start Life Support
+		StopActionName = Stop Life Support
+		CrewCapacity = 3
+		RecyclePercent = 0.25
+
+		INPUT_RESOURCE
+		{
+			ResourceName = ElectricCharge
+			Ratio = 1
+		}
 	}
 	RESOURCE
 	{
@@ -95,7 +201,32 @@
 	@mass -= 0.194
 	MODULE
 	{
-		name = ModuleLifeSupport
+		name = USI_SwapController
+	}
+	MODULE
+	{
+		name = USI_SwappableBay
+		bayName = Bay 1
+		moduleIndex = 0
+	}
+	MODULE
+	{
+		name = USI_Converter
+		UseSpecialistBonus = false
+	}
+	MODULE
+	{
+		name = USILS_LifeSupportRecyclerSwapOption
+		ConverterName = Life Support
+		StartActionName = Start Life Support
+		StopActionName = Stop Life Support
+		RecyclePercent = 0.25
+
+		INPUT_RESOURCE
+		{
+			ResourceName = ElectricCharge
+			Ratio = 1
+		}
 	}
 	RESOURCE
 	{
@@ -121,14 +252,51 @@
 	@mass -= 0.194
 	MODULE
 	{
-		name = ModuleLifeSupport
+		name = USI_SwapController
 	}
 	MODULE
 	{
-		name = ModuleHabitation
+		name = USI_SwappableBay
+		bayName = Bay 1
+		moduleIndex = 0
+	}
+	MODULE
+	{
+		name = USI_Converter
+		UseSpecialistBonus = false
+	}
+	MODULE
+	{
+		name = USILS_LifeSupportRecyclerSwapOption
+		ConverterName = Life Support
+		StartActionName = Start Life Support
+		StopActionName = Stop Life Support
+		CrewCapacity = 6
+		RecyclePercent = 0.5
+
+		INPUT_RESOURCE
+		{
+			ResourceName = ElectricCharge
+			Ratio = 1
+		}
+	}
+	MODULE 
+	{
+		name = USILS_HabitationSwapOption
+		ConverterName = Habitat
+		StartActionName = Start Habitat
+		StopActionName = Stop Habitat		
+
 		BaseKerbalMonths = 6
 		BaseHabMultiplier = 0
 		CrewCapacity = 6
+
+
+		INPUT_RESOURCE
+		{
+			ResourceName = ElectricCharge
+			Ratio = 0.125
+		}
 	}
 	RESOURCE
 	{
@@ -149,14 +317,51 @@
 	@mass -= 0.194
 	MODULE
 	{
-		name = ModuleLifeSupport
+		name = USI_SwapController
 	}
 	MODULE
 	{
-		name = ModuleHabitation
+		name = USI_SwappableBay
+		bayName = Bay 1
+		moduleIndex = 0
+	}
+	MODULE
+	{
+		name = USI_Converter
+		UseSpecialistBonus = false
+	}
+	MODULE
+	{
+		name = USILS_LifeSupportRecyclerSwapOption
+		ConverterName = Life Support
+		StartActionName = Start Life Support
+		StopActionName = Stop Life Support
+		CrewCapacity = 6
+		RecyclePercent = 0.5
+
+		INPUT_RESOURCE
+		{
+			ResourceName = ElectricCharge
+			Ratio = 1
+		}
+	}
+	MODULE 
+	{
+		name = USILS_HabitationSwapOption
+		ConverterName = Habitat
+		StartActionName = Start Habitat
+		StopActionName = Stop Habitat		
+
 		BaseKerbalMonths = 6
 		BaseHabMultiplier = 0
 		CrewCapacity = 6
+
+
+		INPUT_RESOURCE
+		{
+			ResourceName = ElectricCharge
+			Ratio = 0.125
+		}
 	}
 	RESOURCE
 	{
@@ -177,7 +382,32 @@
 	@mass -= 0.583
 	MODULE
 	{
-		name = ModuleLifeSupport
+		name = USI_SwapController
+	}
+	MODULE
+	{
+		name = USI_SwappableBay
+		bayName = Bay 1
+		moduleIndex = 0
+	}
+	MODULE
+	{
+		name = USI_Converter
+		UseSpecialistBonus = false
+	}
+	MODULE
+	{
+		name = USILS_LifeSupportRecyclerSwapOption
+		ConverterName = Life Support
+		StartActionName = Start Life Support
+		StopActionName = Stop Life Support
+		RecyclePercent = 0.5
+
+		INPUT_RESOURCE
+		{
+			ResourceName = ElectricCharge
+			Ratio = 1
+		}
 	}
 	RESOURCE
 	{
@@ -202,14 +432,51 @@
 	@mass -= 0.907
 	MODULE
 	{
-		name = ModuleLifeSupport
+		name = USI_SwapController
 	}
 	MODULE
 	{
-		name = ModuleHabitation
+		name = USI_SwappableBay
+		bayName = Bay 1
+		moduleIndex = 0
+	}
+	MODULE
+	{
+		name = USI_Converter
+		UseSpecialistBonus = false
+	}
+	MODULE
+	{
+		name = USILS_LifeSupportRecyclerSwapOption
+		ConverterName = Life Support
+		StartActionName = Start Life Support
+		StopActionName = Stop Life Support
+		CrewCapacity = 7
+		RecyclePercent = 0.5
+
+		INPUT_RESOURCE
+		{
+			ResourceName = ElectricCharge
+			Ratio = 1
+		}
+	}
+	MODULE 
+	{
+		name = USILS_HabitationSwapOption
+		ConverterName = Habitat
+		StartActionName = Start Habitat
+		StopActionName = Stop Habitat		
+
 		BaseKerbalMonths = 7
 		BaseHabMultiplier = 0
 		CrewCapacity = 7
+
+
+		INPUT_RESOURCE
+		{
+			ResourceName = ElectricCharge
+			Ratio = 0.125
+		}
 	}
 	RESOURCE
 	{
@@ -225,20 +492,57 @@
 	}
 }
 
-Shuttle CM 12 days x 7 kerbals x 10.8 = 907
+//Shuttle CM 12 days x 7 kerbals x 10.8 = 907
 @PART[SSTU-SC-E-FSX]:FOR[SSTU]:NEEDS[USILifeSupport] //Shuttle
 {
 	@mass -= 0.907
 	MODULE
 	{
-		name = ModuleLifeSupport
+		name = USI_SwapController
 	}
 	MODULE
 	{
-		name = ModuleHabitation
+		name = USI_SwappableBay
+		bayName = Bay 1
+		moduleIndex = 0
+	}
+	MODULE
+	{
+		name = USI_Converter
+		UseSpecialistBonus = false
+	}
+	MODULE
+	{
+		name = USILS_LifeSupportRecyclerSwapOption
+		ConverterName = Life Support
+		StartActionName = Start Life Support
+		StopActionName = Stop Life Support
+		CrewCapacity = 7
+		RecyclePercent = 0.5
+
+		INPUT_RESOURCE
+		{
+			ResourceName = ElectricCharge
+			Ratio = 1
+		}
+	}
+	MODULE 
+	{
+		name = USILS_HabitationSwapOption
+		ConverterName = Habitat
+		StartActionName = Start Habitat
+		StopActionName = Stop Habitat		
+
 		BaseKerbalMonths = 7
 		BaseHabMultiplier = 0
 		CrewCapacity = 7
+
+
+		INPUT_RESOURCE
+		{
+			ResourceName = ElectricCharge
+			Ratio = 0.125
+		}
 	}
 	RESOURCE
 	{
@@ -261,7 +565,33 @@ Shuttle CM 12 days x 7 kerbals x 10.8 = 907
 	@mass -= 0.146
 	MODULE
 	{
-		name = ModuleLifeSupport
+		name = USI_SwapController
+	}
+	MODULE
+	{
+		name = USI_SwappableBay
+		bayName = Bay 1
+		moduleIndex = 0
+	}
+	MODULE
+	{
+		name = USI_Converter
+		UseSpecialistBonus = false
+	}
+	MODULE
+	{
+		name = USILS_LifeSupportRecyclerSwapOption
+		ConverterName = Life Support
+		StartActionName = Start Life Support
+		StopActionName = Stop Life Support
+		CrewCapacity = 3
+		RecyclePercent = 0.25
+
+		INPUT_RESOURCE
+		{
+			ResourceName = ElectricCharge
+			Ratio = 1
+		}
 	}
 	RESOURCE
 	{

--- a/GameData/SSTU/ModIntegration/USI/USI-LS/USI-LS-ST.cfg
+++ b/GameData/SSTU/ModIntegration/USI/USI-LS/USI-LS-ST.cfg
@@ -37,18 +37,22 @@
 	}
 	MODULE
 	{
-		name = ModuleLifeSupport
+		name = USI_SwapController
 	}
 	MODULE
 	{
-		name = ModuleHabitation
-		BaseKerbalMonths = 24
-		BaseHabMultiplier = 1
-		CrewCapacity = 12
+		name = USI_SwappableBay
+		bayName = Bay 1
+		moduleIndex = 0
 	}
 	MODULE
 	{
-		name = ModuleLifeSupportRecycler
+		name = USI_Converter
+		UseSpecialistBonus = false
+	}
+	MODULE
+	{
+		name = USILS_LifeSupportRecyclerSwapOption
 		CrewCapacity = 6
 		RecyclePercent = 0.9
 		ConverterName = Life Support
@@ -61,6 +65,17 @@
 			ResourceName = ElectricCharge
 			Ratio = 1
 		}
+	}
+	MODULE 
+	{
+		name = USILS_HabitationSwapOption
+		ConverterName = Habitat
+		StartActionName = Start Habitat
+		StopActionName = Stop Habitat
+
+		BaseKerbalMonths = 24
+		BaseHabMultiplier = 1
+		CrewCapacity = 12
 	}
 }
 @PART[SSTU-ST-CFG-B]:FOR[SSTU]:NEEDS[USILifeSupport]
@@ -102,18 +117,22 @@
 	}
 	MODULE
 	{
-		name = ModuleLifeSupport
+		name = USI_SwapController
 	}
 	MODULE
 	{
-		name = ModuleHabitation
-		BaseKerbalMonths = 48
-		BaseHabMultiplier = 2
-		CrewCapacity = 24
+		name = USI_SwappableBay
+		bayName = Bay 1
+		moduleIndex = 0
 	}
 	MODULE
 	{
-		name = ModuleLifeSupportRecycler
+		name = USI_Converter
+		UseSpecialistBonus = false
+	}
+	MODULE
+	{
+		name = USILS_LifeSupportRecyclerSwapOption
 		CrewCapacity = 12
 		RecyclePercent = 0.9
 		ConverterName = Life Support
@@ -126,6 +145,16 @@
 			ResourceName = ElectricCharge
 			Ratio = 1
 		}
+	}
+	MODULE 
+	{
+		name = USILS_HabitationSwapOption
+		ConverterName = Habitat
+		StartActionName = Start Habitat
+		StopActionName = Stop Habitat		
+		BaseKerbalMonths = 48
+		BaseHabMultiplier = 2
+		CrewCapacity = 24
 	}
 }
 @PART[SSTU-ST-CFG-C]:FOR[SSTU]:NEEDS[USILifeSupport]
@@ -167,30 +196,44 @@
 	}
 	MODULE
 	{
-		name = ModuleLifeSupport
+		name = USI_SwapController
 	}
 	MODULE
 	{
-		name = ModuleHabitation
-		BaseKerbalMonths = 80
-		BaseHabMultiplier = 3
-		CrewCapacity = 40
+		name = USI_SwappableBay
+		bayName = Bay 1
+		moduleIndex = 0
 	}
 	MODULE
 	{
-		name = ModuleLifeSupportRecycler
-		CrewCapacity = 20
-		RecyclePercent = 0.9
+		name = USI_Converter
+		UseSpecialistBonus = false
+	}
+	MODULE
+	{
+		name = USILS_LifeSupportRecyclerSwapOption
 		ConverterName = Life Support
 		tag = Life Support
 		StartActionName = Start Life Support
 		StopActionName = Stop Life Support
+		CrewCapacity = 20
+		RecyclePercent = 0.9
 
 		INPUT_RESOURCE
 		{
 			ResourceName = ElectricCharge
 			Ratio = 1
 		}
+	}
+	MODULE 
+	{
+		name = USILS_HabitationSwapOption
+		ConverterName = Habitat
+		StartActionName = Start Habitat
+		StopActionName = Stop Habitat		
+		BaseKerbalMonths = 80
+		BaseHabMultiplier = 3
+		CrewCapacity = 40
 	}
 }
 @PART[SSTU-ST-CFG-D]:FOR[SSTU]:NEEDS[USILifeSupport]
@@ -232,18 +275,22 @@
 	}
 	MODULE
 	{
-		name = ModuleLifeSupport
+		name = USI_SwapController
 	}
 	MODULE
 	{
-		name = ModuleHabitation
-		BaseKerbalMonths = 120
-		BaseHabMultiplier = 3
-		CrewCapacity = 60
+		name = USI_SwappableBay
+		bayName = Bay 1
+		moduleIndex = 0
 	}
 	MODULE
 	{
-		name = ModuleLifeSupportRecycler
+		name = USI_Converter
+		UseSpecialistBonus = false
+	}
+	MODULE
+	{
+		name = USILS_LifeSupportRecyclerSwapOption
 		CrewCapacity = 30
 		RecyclePercent = 0.9
 		ConverterName = Life Support
@@ -256,6 +303,13 @@
 			ResourceName = ElectricCharge
 			Ratio = 1
 		}
+	}
+	MODULE 
+	{
+		name = USILS_HabitationSwapOption
+		BaseKerbalMonths = 120
+		BaseHabMultiplier = 3
+		CrewCapacity = 60
 	}
 }
 
@@ -293,18 +347,22 @@
 	}
 	MODULE
 	{
-		name = ModuleLifeSupport
+		name = USI_SwapController
 	}
 	MODULE
 	{
-		name = ModuleHabitation
-		BaseKerbalMonths = 2
-		BaseHabMultiplier = 0
-		CrewCapacity = 1
+		name = USI_SwappableBay
+		bayName = Bay 1
+		moduleIndex = 0
 	}
 	MODULE
 	{
-		name = ModuleLifeSupportRecycler
+		name = USI_Converter
+		UseSpecialistBonus = false
+	}
+	MODULE
+	{
+		name = USILS_LifeSupportRecyclerSwapOption
 		CrewCapacity = 1
 		RecyclePercent = 0.9
 		ConverterName = Life Support
@@ -317,6 +375,13 @@
 			ResourceName = ElectricCharge
 			Ratio = 1
 		}
+	}
+	MODULE 
+	{
+		name = USILS_HabitationSwapOption
+		BaseKerbalMonths = 2
+		BaseHabMultiplier = 0
+		CrewCapacity = 1
 	}
 }
 
@@ -352,18 +417,22 @@
 	}
 	MODULE
 	{
-		name = ModuleLifeSupport
+		name = USI_SwapController
 	}
 	MODULE
 	{
-		name = ModuleHabitation
-		BaseKerbalMonths = 4
-		BaseHabMultiplier = 0
-		CrewCapacity = 2
-	}	
+		name = USI_SwappableBay
+		bayName = Bay 1
+		moduleIndex = 0
+	}
 	MODULE
 	{
-		name = ModuleLifeSupportRecycler
+		name = USI_Converter
+		UseSpecialistBonus = false
+	}
+	MODULE
+	{
+		name = USILS_LifeSupportRecyclerSwapOption
 		CrewCapacity = 2
 		RecyclePercent = 0.9
 		ConverterName = Life Support
@@ -377,6 +446,13 @@
 			Ratio = 1
 		}
 	}
+		MODULE 
+	{
+		name = USILS_HabitationSwapOption
+		BaseKerbalMonths = 4
+		BaseHabMultiplier = 0
+		CrewCapacity = 2
+	}	
 }
 
 @PART[SSTU-ST-COS-HAB-M]:FOR[SSTU]:NEEDS[USILifeSupport]
@@ -411,18 +487,22 @@
 	}
 	MODULE
 	{
-		name = ModuleLifeSupport
+		name = USI_SwapController
 	}
 	MODULE
 	{
-		name = ModuleHabitation
-		BaseKerbalMonths = 6
-		BaseHabMultiplier = 1
-		CrewCapacity = 3
-	}	
+		name = USI_SwappableBay
+		bayName = Bay 1
+		moduleIndex = 0
+	}
 	MODULE
 	{
-		name = ModuleLifeSupportRecycler
+		name = USI_Converter
+		UseSpecialistBonus = false
+	}
+	MODULE
+	{
+		name = USILS_LifeSupportRecyclerSwapOption
 		CrewCapacity = 4
 		RecyclePercent = 0.9
 		ConverterName = Life Support
@@ -436,6 +516,13 @@
 			Ratio = 1
 		}
 	}
+	MODULE 
+	{
+		name = USILS_HabitationSwapOption
+		BaseKerbalMonths = 6
+		BaseHabMultiplier = 1
+		CrewCapacity = 3
+	}	
 }
 
 @PART[SSTU-ST-COS-HAB-L]:FOR[SSTU]:NEEDS[USILifeSupport]
@@ -470,18 +557,22 @@
 	}
 	MODULE
 	{
-		name = ModuleLifeSupport
+		name = USI_SwapController
 	}
 	MODULE
 	{
-		name = ModuleHabitation
-		BaseKerbalMonths = 10
-		BaseHabMultiplier = 2
-		CrewCapacity = 5
-	}	
+		name = USI_SwappableBay
+		bayName = Bay 1
+		moduleIndex = 0
+	}
 	MODULE
 	{
-		name = ModuleLifeSupportRecycler
+		name = USI_Converter
+		UseSpecialistBonus = false
+	}
+	MODULE
+	{
+		name = USILS_LifeSupportRecyclerSwapOption
 		CrewCapacity = 6
 		RecyclePercent = 0.9
 		ConverterName = Life Support
@@ -495,6 +586,13 @@
 			Ratio = 1
 		}
 	}
+	MODULE 
+	{
+		name = USILS_HabitationSwapOption
+		BaseKerbalMonths = 10
+		BaseHabMultiplier = 2
+		CrewCapacity = 5
+	}	
 }
 
 @PART[SSTU-ST-COS-LAB-S]:FOR[SSTU]:NEEDS[USILifeSupport]
@@ -529,18 +627,22 @@
 	}
 	MODULE
 	{
-		name = ModuleLifeSupport
+		name = USI_SwapController
 	}
 	MODULE
 	{
-		name = ModuleHabitation
-		BaseKerbalMonths = 2
-		BaseHabMultiplier = 0
-		CrewCapacity = 1
-	}	
+		name = USI_SwappableBay
+		bayName = Bay 1
+		moduleIndex = 0
+	}
 	MODULE
 	{
-		name = ModuleLifeSupportRecycler
+		name = USI_Converter
+		UseSpecialistBonus = false
+	}
+	MODULE
+	{
+		name = USILS_LifeSupportRecyclerSwapOption
 		CrewCapacity = 2
 		RecyclePercent = 0.9
 		ConverterName = Life Support
@@ -554,6 +656,13 @@
 			Ratio = 1
 		}
 	}
+	MODULE 
+	{
+		name = USILS_HabitationSwapOption
+		BaseKerbalMonths = 2
+		BaseHabMultiplier = 0
+		CrewCapacity = 1
+	}	
 }
 
 @PART[SSTU-ST-COS-LAB-M]:FOR[SSTU]:NEEDS[USILifeSupport]
@@ -588,18 +697,22 @@
 	}
 	MODULE
 	{
-		name = ModuleLifeSupport
+		name = USI_SwapController
 	}
 	MODULE
 	{
-		name = ModuleHabitation
-		BaseKerbalMonths = 4
-		BaseHabMultiplier = 0
-		CrewCapacity = 2
-	}	
+		name = USI_SwappableBay
+		bayName = Bay 1
+		moduleIndex = 0
+	}
 	MODULE
 	{
-		name = ModuleLifeSupportRecycler
+		name = USI_Converter
+		UseSpecialistBonus = false
+	}
+	MODULE
+	{
+		name = USILS_LifeSupportRecyclerSwapOption
 		CrewCapacity = 4
 		RecyclePercent = 0.9
 		ConverterName = Life Support
@@ -613,6 +726,13 @@
 			Ratio = 1
 		}
 	}
+	MODULE 
+	{
+		name = USILS_HabitationSwapOption
+		BaseKerbalMonths = 4
+		BaseHabMultiplier = 0
+		CrewCapacity = 2
+	}	
 }
 
 @PART[SSTU-ST-COS-LAB-L]:FOR[SSTU]:NEEDS[USILifeSupport]
@@ -647,18 +767,22 @@
 	}
 	MODULE
 	{
-		name = ModuleLifeSupport
+		name = USI_SwapController
 	}
 	MODULE
 	{
-		name = ModuleHabitation
-		BaseKerbalMonths = 6
-		BaseHabMultiplier = 0
-		CrewCapacity = 3
-	}	
+		name = USI_SwappableBay
+		bayName = Bay 1
+		moduleIndex = 0
+	}
 	MODULE
 	{
-		name = ModuleLifeSupportRecycler
+		name = USI_Converter
+		UseSpecialistBonus = false
+	}
+	MODULE
+	{
+		name = USILS_LifeSupportRecyclerSwapOption
 		CrewCapacity = 6
 		RecyclePercent = 0.9
 		ConverterName = Life Support
@@ -672,6 +796,13 @@
 			Ratio = 1
 		}
 	}
+	MODULE 
+	{
+		name = USILS_HabitationSwapOption
+		BaseKerbalMonths = 6
+		BaseHabMultiplier = 0
+		CrewCapacity = 3
+	}	
 }
 
 
@@ -712,18 +843,22 @@
 	}
 	MODULE
 	{
-		name = ModuleLifeSupport
+		name = USI_SwapController
 	}
 	MODULE
 	{
-		name = ModuleHabitation
-		BaseKerbalMonths = 4
-		BaseHabMultiplier = 0
-		CrewCapacity = 2
-	}	
+		name = USI_SwappableBay
+		bayName = Bay 1
+		moduleIndex = 0
+	}
 	MODULE
 	{
-		name = ModuleLifeSupportRecycler
+		name = USI_Converter
+		UseSpecialistBonus = false
+	}
+	MODULE
+	{
+		name = USILS_LifeSupportRecyclerSwapOption
 		CrewCapacity = 2
 		RecyclePercent = 0.9
 		ConverterName = Life Support
@@ -737,6 +872,13 @@
 			Ratio = 1
 		}
 	}
+	MODULE 
+	{
+		name = USILS_HabitationSwapOption
+		BaseKerbalMonths = 4
+		BaseHabMultiplier = 0
+		CrewCapacity = 2
+	}	
 }
 @PART[SSTU-ST-DOS-FEM]:FOR[SSTU]:NEEDS[USILifeSupport]
 {
@@ -774,18 +916,22 @@
 	}
 	MODULE
 	{
-		name = ModuleLifeSupport
+		name = USI_SwapController
 	}
 	MODULE
 	{
-		name = ModuleHabitation
-		BaseKerbalMonths = 6
-		BaseHabMultiplier = 2
-		CrewCapacity = 3
-	}	
+		name = USI_SwappableBay
+		bayName = Bay 1
+		moduleIndex = 0
+	}
 	MODULE
 	{
-		name = ModuleLifeSupportRecycler
+		name = USI_Converter
+		UseSpecialistBonus = false
+	}
+	MODULE
+	{
+		name = USILS_LifeSupportRecyclerSwapOption
 		CrewCapacity = 4
 		RecyclePercent = 0.9
 		ConverterName = Life Support
@@ -799,6 +945,13 @@
 			Ratio = 1
 		}
 	}
+	MODULE 
+	{
+		name = USILS_HabitationSwapOption
+		BaseKerbalMonths = 6
+		BaseHabMultiplier = 2
+		CrewCapacity = 3
+	}	
 }
 @PART[SSTU-ST-DOS-HAB]:FOR[SSTU]:NEEDS[USILifeSupport]
 {
@@ -836,18 +989,22 @@
 	}
 	MODULE
 	{
-		name = ModuleLifeSupport
+		name = USI_SwapController
 	}
 	MODULE
 	{
-		name = ModuleHabitation
-		BaseKerbalMonths = 6
-		BaseHabMultiplier = 1
-		CrewCapacity = 3
+		name = USI_SwappableBay
+		bayName = Bay 1
+		moduleIndex = 0
 	}
 	MODULE
 	{
-		name = ModuleLifeSupportRecycler
+		name = USI_Converter
+		UseSpecialistBonus = false
+	}
+	MODULE
+	{
+		name = USILS_LifeSupportRecyclerSwapOption
 		CrewCapacity = 4
 		RecyclePercent = 0.9
 		ConverterName = Life Support
@@ -860,6 +1017,13 @@
 			ResourceName = ElectricCharge
 			Ratio = 1
 		}
+	}
+	MODULE 
+	{
+		name = USILS_HabitationSwapOption
+		BaseKerbalMonths = 6
+		BaseHabMultiplier = 1
+		CrewCapacity = 3
 	}
 }
 @PART[SSTU-ST-DOS-LAB]:FOR[SSTU]:NEEDS[USILifeSupport]
@@ -898,11 +1062,22 @@
 	}
 	MODULE
 	{
-		name = ModuleLifeSupport
+		name = USI_SwapController
 	}
 	MODULE
 	{
-		name = ModuleHabitation
+		name = USI_SwappableBay
+		bayName = Bay 1
+		moduleIndex = 0
+	}
+	MODULE
+	{
+		name = USI_Converter
+		UseSpecialistBonus = false
+	}
+	MODULE 
+	{
+		name = USILS_HabitationSwapOption
 		BaseKerbalMonths = 4
 		BaseHabMultiplier = 0
 		CrewCapacity = 2
@@ -944,11 +1119,22 @@
 	}
 	MODULE
 	{
-		name = ModuleLifeSupport
+		name = USI_SwapController
 	}
 	MODULE
 	{
-		name = ModuleHabitation
+		name = USI_SwappableBay
+		bayName = Bay 1
+		moduleIndex = 0
+	}
+	MODULE
+	{
+		name = USI_Converter
+		UseSpecialistBonus = false
+	}
+	MODULE 
+	{
+		name = USILS_HabitationSwapOption
 		BaseKerbalMonths = 4
 		BaseHabMultiplier = 0
 		CrewCapacity = 2
@@ -990,18 +1176,22 @@
 	}
 	MODULE
 	{
-		name = ModuleLifeSupport
+		name = USI_SwapController
 	}
 	MODULE
 	{
-		name = ModuleHabitation
-		BaseKerbalMonths = 4
-		BaseHabMultiplier = 0
-		CrewCapacity = 2
-	}	
+		name = USI_SwappableBay
+		bayName = Bay 1
+		moduleIndex = 0
+	}
 	MODULE
 	{
-		name = ModuleLifeSupportRecycler
+		name = USI_Converter
+		UseSpecialistBonus = false
+	}
+	MODULE
+	{
+		name = USILS_LifeSupportRecyclerSwapOption
 		CrewCapacity = 2
 		RecyclePercent = 0.9
 		ConverterName = Life Support
@@ -1015,6 +1205,13 @@
 			Ratio = 1
 		}
 	}
+	MODULE 
+	{
+		name = USILS_HabitationSwapOption
+		BaseKerbalMonths = 4
+		BaseHabMultiplier = 0
+		CrewCapacity = 2
+	}	
 }
 
 
@@ -1051,18 +1248,22 @@
 	}
 	MODULE
 	{
-		name = ModuleLifeSupport
+		name = USI_SwapController
 	}
 	MODULE
 	{
-		name = ModuleHabitation
-		BaseKerbalMonths = 4
-		BaseHabMultiplier = 1
-		CrewCapacity = 2
+		name = USI_SwappableBay
+		bayName = Bay 1
+		moduleIndex = 0
 	}
 	MODULE
 	{
-		name = ModuleLifeSupportRecycler
+		name = USI_Converter
+		UseSpecialistBonus = false
+	}
+	MODULE
+	{
+		name = USILS_LifeSupportRecyclerSwapOption
 		CrewCapacity = 2
 		RecyclePercent = 0.9
 		ConverterName = Life Support
@@ -1075,6 +1276,13 @@
 			ResourceName = ElectricCharge
 			Ratio = 1
 		}
+	}
+	MODULE 
+	{
+		name = USILS_HabitationSwapOption
+		BaseKerbalMonths = 4
+		BaseHabMultiplier = 1
+		CrewCapacity = 2
 	}
 }
 @PART[SSTU-ST-HAB-A2]:FOR[SSTU]:NEEDS[USILifeSupport]
@@ -1109,18 +1317,22 @@
 	}
 	MODULE
 	{
-		name = ModuleLifeSupport
+		name = USI_SwapController
 	}
 	MODULE
 	{
-		name = ModuleHabitation
-		BaseKerbalMonths = 6
-		BaseHabMultiplier = 1
-		CrewCapacity = 3
+		name = USI_SwappableBay
+		bayName = Bay 1
+		moduleIndex = 0
 	}
 	MODULE
 	{
-		name = ModuleLifeSupportRecycler
+		name = USI_Converter
+		UseSpecialistBonus = false
+	}
+	MODULE
+	{
+		name = USILS_LifeSupportRecyclerSwapOption
 		CrewCapacity = 3
 		RecyclePercent = 0.9
 		ConverterName = Life Support
@@ -1133,6 +1345,13 @@
 			ResourceName = ElectricCharge
 			Ratio = 1
 		}
+	}
+	MODULE 
+	{
+		name = USILS_HabitationSwapOption
+		BaseKerbalMonths = 6
+		BaseHabMultiplier = 1
+		CrewCapacity = 3
 	}
 }
 
@@ -1172,18 +1391,22 @@
 	}
 	MODULE
 	{
-		name = ModuleLifeSupport
+		name = USI_SwapController
 	}
 	MODULE
 	{
-		name = ModuleHabitation
-		BaseKerbalMonths = 20
-		BaseHabMultiplier = 2
-		CrewCapacity = 10
+		name = USI_SwappableBay
+		bayName = Bay 1
+		moduleIndex = 0
 	}
 	MODULE
 	{
-		name = ModuleLifeSupportRecycler
+		name = USI_Converter
+		UseSpecialistBonus = false
+	}
+	MODULE
+	{
+		name = USILS_LifeSupportRecyclerSwapOption
 		CrewCapacity = 5
 		RecyclePercent = 0.9
 		ConverterName = Life Support
@@ -1196,6 +1419,13 @@
 			ResourceName = ElectricCharge
 			Ratio = 1
 		}
+	}
+	MODULE 
+	{
+		name = USILS_HabitationSwapOption
+		BaseKerbalMonths = 20
+		BaseHabMultiplier = 2
+		CrewCapacity = 10
 	}
 }
 @PART[SSTU-ST-HAB-B2]:FOR[SSTU]:NEEDS[USILifeSupport]
@@ -1234,18 +1464,22 @@
 	}
 	MODULE
 	{
-		name = ModuleLifeSupport
+		name = USI_SwapController
 	}
 	MODULE
 	{
-		name = ModuleHabitation
-		BaseKerbalMonths = 30
-		BaseHabMultiplier = 2
-		CrewCapacity = 15
+		name = USI_SwappableBay
+		bayName = Bay 1
+		moduleIndex = 0
 	}
 	MODULE
 	{
-		name = ModuleLifeSupportRecycler
+		name = USI_Converter
+		UseSpecialistBonus = false
+	}
+	MODULE
+	{
+		name = USILS_LifeSupportRecyclerSwapOption
 		CrewCapacity = 8
 		RecyclePercent = 0.9
 		ConverterName = Life Support
@@ -1258,6 +1492,13 @@
 			ResourceName = ElectricCharge
 			Ratio = 1
 		}
+	}
+	MODULE 
+	{
+		name = USILS_HabitationSwapOption
+		BaseKerbalMonths = 30
+		BaseHabMultiplier = 2
+		CrewCapacity = 15
 	}
 }
 @PART[SSTU-ST-HAB-B3]:FOR[SSTU]:NEEDS[USILifeSupport]
@@ -1292,18 +1533,22 @@
 	}
 	MODULE
 	{
-		name = ModuleLifeSupport
+		name = USI_SwapController
 	}
 	MODULE
 	{
-		name = ModuleHabitation
-		BaseKerbalMonths = 20
-		BaseHabMultiplier = 2
-		CrewCapacity = 10
+		name = USI_SwappableBay
+		bayName = Bay 1
+		moduleIndex = 0
 	}
 	MODULE
 	{
-		name = ModuleLifeSupportRecycler
+		name = USI_Converter
+		UseSpecialistBonus = false
+	}
+	MODULE
+	{
+		name = USILS_LifeSupportRecyclerSwapOption
 		CrewCapacity = 5
 		RecyclePercent = 0.9
 		ConverterName = Life Support
@@ -1316,6 +1561,13 @@
 			ResourceName = ElectricCharge
 			Ratio = 1
 		}
+	}
+	MODULE 
+	{
+		name = USILS_HabitationSwapOption
+		BaseKerbalMonths = 20
+		BaseHabMultiplier = 2
+		CrewCapacity = 10
 	}
 }
 @PART[SSTU-ST-HAB-B4]:FOR[SSTU]:NEEDS[USILifeSupport]
@@ -1350,18 +1602,22 @@
 	}
 	MODULE
 	{
-		name = ModuleLifeSupport
+		name = USI_SwapController
 	}
 	MODULE
 	{
-		name = ModuleHabitation
-		BaseKerbalMonths = 30
-		BaseHabMultiplier = 2
-		CrewCapacity = 15
+		name = USI_SwappableBay
+		bayName = Bay 1
+		moduleIndex = 0
 	}
 	MODULE
 	{
-		name = ModuleLifeSupportRecycler
+		name = USI_Converter
+		UseSpecialistBonus = false
+	}
+	MODULE
+	{
+		name = USILS_LifeSupportRecyclerSwapOption
 		CrewCapacity = 8
 		RecyclePercent = 0.9
 		ConverterName = Life Support
@@ -1374,6 +1630,13 @@
 			ResourceName = ElectricCharge
 			Ratio = 1
 		}
+	}
+	MODULE 
+	{
+		name = USILS_HabitationSwapOption
+		BaseKerbalMonths = 30
+		BaseHabMultiplier = 2
+		CrewCapacity = 15
 	}
 }
 
@@ -1414,18 +1677,22 @@
 	}
 	MODULE
 	{
-		name = ModuleLifeSupport
+		name = USI_SwapController
 	}
 	MODULE
 	{
-		name = ModuleHabitation
-		BaseKerbalMonths = 48
-		BaseHabMultiplier = 2
-		CrewCapacity = 24
+		name = USI_SwappableBay
+		bayName = Bay 1
+		moduleIndex = 0
 	}
 	MODULE
 	{
-		name = ModuleLifeSupportRecycler
+		name = USI_Converter
+		UseSpecialistBonus = false
+	}
+	MODULE
+	{
+		name = USILS_LifeSupportRecyclerSwapOption
 		CrewCapacity = 12
 		RecyclePercent = 0.9
 		ConverterName = Life Support
@@ -1438,6 +1705,13 @@
 			ResourceName = ElectricCharge
 			Ratio = 1
 		}
+	}
+	MODULE 
+	{
+		name = USILS_HabitationSwapOption
+		BaseKerbalMonths = 48
+		BaseHabMultiplier = 2
+		CrewCapacity = 24
 	}
 }
 @PART[SSTU-ST-HAB-C2]:FOR[SSTU]:NEEDS[USILifeSupport]
@@ -1476,18 +1750,22 @@
 	}
 	MODULE
 	{
-		name = ModuleLifeSupport
+		name = USI_SwapController
 	}
 	MODULE
 	{
-		name = ModuleHabitation
-		BaseKerbalMonths = 72
-		BaseHabMultiplier = 2
-		CrewCapacity = 36
+		name = USI_SwappableBay
+		bayName = Bay 1
+		moduleIndex = 0
 	}
 	MODULE
 	{
-		name = ModuleLifeSupportRecycler
+		name = USI_Converter
+		UseSpecialistBonus = false
+	}
+	MODULE
+	{
+		name = USILS_LifeSupportRecyclerSwapOption
 		CrewCapacity = 18
 		RecyclePercent = 0.9
 		ConverterName = Life Support
@@ -1500,6 +1778,13 @@
 			ResourceName = ElectricCharge
 			Ratio = 1
 		}
+	}
+	MODULE 
+	{
+		name = USILS_HabitationSwapOption
+		BaseKerbalMonths = 72
+		BaseHabMultiplier = 2
+		CrewCapacity = 36
 	}
 }
 @PART[SSTU-ST-HAB-C3]:FOR[SSTU]:NEEDS[USILifeSupport]
@@ -1534,18 +1819,22 @@
 	}
 	MODULE
 	{
-		name = ModuleLifeSupport
+		name = USI_SwapController
 	}
 	MODULE
 	{
-		name = ModuleHabitation
-		BaseKerbalMonths = 48
-		BaseHabMultiplier = 2
-		CrewCapacity = 24
+		name = USI_SwappableBay
+		bayName = Bay 1
+		moduleIndex = 0
 	}
 	MODULE
 	{
-		name = ModuleLifeSupportRecycler
+		name = USI_Converter
+		UseSpecialistBonus = false
+	}
+	MODULE
+	{
+		name = USILS_LifeSupportRecyclerSwapOption
 		CrewCapacity = 12
 		RecyclePercent = 0.9
 		ConverterName = Life Support
@@ -1558,6 +1847,13 @@
 			ResourceName = ElectricCharge
 			Ratio = 1
 		}
+	}
+	MODULE 
+	{
+		name = USILS_HabitationSwapOption
+		BaseKerbalMonths = 48
+		BaseHabMultiplier = 2
+		CrewCapacity = 24
 	}
 }
 @PART[SSTU-ST-HAB-C4]:FOR[SSTU]:NEEDS[USILifeSupport]
@@ -1592,18 +1888,22 @@
 	}
 	MODULE
 	{
-		name = ModuleLifeSupport
+		name = USI_SwapController
 	}
 	MODULE
 	{
-		name = ModuleHabitation
-		BaseKerbalMonths = 72
-		BaseHabMultiplier = 2
-		CrewCapacity = 36
+		name = USI_SwappableBay
+		bayName = Bay 1
+		moduleIndex = 0
 	}
 	MODULE
 	{
-		name = ModuleLifeSupportRecycler
+		name = USI_Converter
+		UseSpecialistBonus = false
+	}
+	MODULE
+	{
+		name = USILS_LifeSupportRecyclerSwapOption
 		CrewCapacity = 18
 		RecyclePercent = 0.9
 		ConverterName = Life Support
@@ -1616,5 +1916,12 @@
 			ResourceName = ElectricCharge
 			Ratio = 1
 		}
+	}
+	MODULE 
+	{
+		name = USILS_HabitationSwapOption
+		BaseKerbalMonths = 72
+		BaseHabMultiplier = 2
+		CrewCapacity = 36
 	}
 }


### PR DESCRIPTION
Here's a quick and dirty update to the currently included USI-LS patches.   This updates all relevant parts to add `USI_SwapController`, `USI_SwappableBay,` and `USI_Converter` modules, and changes the old Life Support and Habitat modules to the new `USILS_LifeSupportRecyclerSwapOption` and `USILS_HabitationSwapOption` so they work on newer versions of USI-LS.

Where necessary to add life support or habitat values,  I used values from other similar parts that I could find configs for (3 person crew module recycler percentage the same as 3 person crew pod from Near Future Spacecraft, for instance).  These values may not be balanced but I won't know until I really dig in and give them a test, which I intend to do over the next week or two.  For the SSTU Hab parts, all I really did was a quick find/replace job to make them all work, I didn't change any of the already existing values.

I can't speak to the balance of this patch since I tried to keep it as close to original as I could.  I'll have to explore that further in my own testing, but I do welcome feedback and will make adjustments if anything is wildly out of balance.   In any case,  I figure having a patch that works, even if it's a little unbalanced, is better than having a patch that's outdated and doesn't do anything. 
